### PR TITLE
Use curl instead of wget to get LLVM key

### DIFF
--- a/builder/imports/llvm.py
+++ b/builder/imports/llvm.py
@@ -84,7 +84,7 @@ esac
 
 
 # install everything
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 add-apt-repository "${REPO_NAME}"
 apt-get update 
 apt-get install -y clang-$LLVM_VERSION lld-$LLVM_VERSION


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
