### PR TITLE
Implemented publish to S3, mirror for JDK

### DIFF
--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -24,6 +24,7 @@ from spec import BuildSpec
 from actions.script import Script
 from actions.install import InstallPackages, InstallCompiler
 from actions.git import DownloadDependencies
+from actions.mirror import Mirror
 from env import Env
 from project import Project
 from scripts import Scripts
@@ -53,15 +54,18 @@ def run_action(action, env):
             sys.exit(13)
         action = action_cls()
 
-    Scripts.run_action(
-        Script([
-            InstallCompiler(),
-            InstallPackages(),
-            DownloadDependencies(),
-            action,
-        ], name='main'),
-        env
-    )
+    if action.is_main():
+        Scripts.run_action(action, env)
+    else:
+        Scripts.run_action(
+            Script([
+                InstallCompiler(),
+                InstallPackages(),
+                DownloadDependencies(),
+                action,
+            ], name='main'),
+            env
+        )
 
     env.shell.popenv()
 
@@ -237,7 +241,7 @@ if __name__ == '__main__':
 
     Scripts.load()
 
-    if not env.project:
+    if not env.project and args.command != 'mirror':
         print('No project specified and no project found in current directory')
         sys.exit(1)
 

--- a/builder/actions/mirror.py
+++ b/builder/actions/mirror.py
@@ -11,16 +11,22 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import os
+from action import Action
+from project import Import
 
-class Action(object):
-    """ A build step """
+
+class Mirror(Action):
+    """ Updates mirrored dependencies in S3/CloudFront """
 
     def is_main(self):
-        """ Returns True if this action needs no external tasks run to set it up """
-        return False
+        return True
 
     def run(self, env):
-        pass
+        import_classes = Import.__subclasses__()
 
-    def __str__(self):
-        return self.__class__.__name__
+        for import_class in import_classes:
+            imp = import_class()
+            if imp.__class__.__dict__.get('mirror', Import.__dict__['mirror']) != Import.__dict__['mirror']:
+                print('Mirroring {}'.format(imp.name))
+                imp.mirror(env)

--- a/builder/imports/jdk.py
+++ b/builder/imports/jdk.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import tarfile
 import zipfile
 
-from fetch import fetch_and_extract
+from fetch import fetch_and_extract, mirror_package
 from project import Import
 import util
 
@@ -125,3 +125,7 @@ class JDK8(Import):
 
         env.variables['java_home'] = self.path
         self.installed = True
+
+    def mirror(self, env):
+        for src_url in URLs.values():
+            mirror_package(self.name, src_url)

--- a/builder/project.py
+++ b/builder/project.py
@@ -329,6 +329,9 @@ class Import(object):
             getattr(self, 'imports', []) + self.config.get('imports', []), spec)
         return self.imports
 
+    def mirror(self, env):
+        pass
+
 
 class Project(object):
     """ Describes a given library and its dependencies/consumers """


### PR DESCRIPTION
The goal here is to reduce our reliance on public infrastructure where we can, and to reduce downloads where possible. We should be able to bake the cache into our docker images, or mount it as a tarball volume, for instance.

This is in preparation for the NDK, which is a couple gigs that I don't want to have to download everywhere all the time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
