### PR TITLE
al2012 needs its own libcrypto because its linker is from the Phoenicians

### DIFF
--- a/.github/docker-images/al2012-x64/Dockerfile
+++ b/.github/docker-images/al2012-x64/Dockerfile
@@ -36,7 +36,7 @@ RUN python3 -m pip install --upgrade pip setuptools virtualenv \
 # Install pre-built OpenSSL
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://d19elf31gohf1l.cloudfront.net/_binaries/libcrypto/libcrypto-1.1.1-linux-x64.tar.gz -o libcrypto.tar.gz \
+RUN curl -sSL https://d19elf31gohf1l.cloudfront.net/_binaries/libcrypto/libcrypto-1.1.1-al2012-x64.tar.gz -o libcrypto.tar.gz \
     && mkdir /opt/openssl \
     && tar xzf libcrypto.tar.gz -C /opt/openssl \
     && LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/openssl/lib /opt/openssl/bin/openssl version \


### PR DESCRIPTION
Offline compiled libcrypto 1.1.1 on al2012 and added to S3 binaries bucket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
