### PR TITLE
Imported release notes script as an action

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -211,7 +211,7 @@ jobs:
           path: .
 
       - name: Build ${{ matrix.project }}
-        run: python3 builder.pyz build --project ${{ matrix.project }}
+        run: python3 builder.pyz release-notes --project ${{ matrix.project }}
 
   # Make sure downstream projects that use the builder compile after any changes
   downstream:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -201,6 +201,9 @@ jobs:
           - aws-iot-device-sdk-java-v2
           - aws-crt-nodejs
           - aws-iot-device-sdk-js-v2
+          - aws-crt-python
+          - aws-iot-device-sdk-python-v2
+
     needs: package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -190,6 +190,29 @@ jobs:
       - name: Build aws-c-common
         run: python3 builder.pyz build --project aws-c-common --compiler=${{ matrix.compiler }} run_tests=false
 
+  release_notes:
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - aws-crt-cpp
+          - aws-iot-device-sdk-cpp-v2
+          - aws-crt-java
+          - aws-iot-device-sdk-java-v2
+          - aws-crt-nodejs
+          - aws-iot-device-sdk-js-v2
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install builder
+        uses: actions/download-artifact@v1
+        with:
+          name: builder
+          path: .
+
+      - name: Build ${{ matrix.project }}
+        run: python3 builder.pyz build --project ${{ matrix.project }}
+
   # Make sure downstream projects that use the builder compile after any changes
   downstream:
     strategy:
@@ -259,5 +282,6 @@ jobs:
     - sanity_test
     - cross_compile
     - compilers
+    - release_notes
     steps:
       - run: echo "All sanity tests passed"

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -15,6 +15,7 @@ from actions.script import Script
 from actions.install import InstallPackages, InstallCompiler
 from actions.git import DownloadDependencies
 from actions.mirror import Mirror
+from actions.release import ReleaseNotes
 from env import Env
 from project import Project
 from scripts import Scripts

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -53,11 +53,7 @@ def print_release_notes(env):
                         action='store_true', help="ignore warnings")
     args = parser.parse_known_args(env.args.args)[0]
 
-    crt_path = sh.cwd()
-    submodules_root_path = os.path.join(crt_path, 'aws-common-runtime')
-    if not os.path.exists(submodules_root_path):
-        print('Must be run from an "aws-crt-*" dir')
-        sys.exit(1)
+    package_path = sh.cwd()
 
     print('Syncing to latest master...')
     sh.exec('git', 'checkout', 'master', quiet=True)
@@ -65,13 +61,13 @@ def print_release_notes(env):
     sh.exec('git', 'submodule', 'update', '--init', quiet=True)
 
     print('Gathering info...')
-    crt_tags = get_all_tags()
-    crt_latest_tag = crt_tags[0]
+    package_tags = get_all_tags()
+    package_latest_tag = package_tags[0]
 
-    crt_changes = sh.exec(
-        'git', 'log', crt_latest_tag['commit'] + '..', quiet=True).output
-    if not crt_changes:
-        print('No changes since last release', crt_latest_tag['str'])
+    package_changes = sh.exec(
+        'git', 'log', package_latest_tag['commit'] + '..', quiet=True).output
+    if not package_changes:
+        print('No changes since last release', package_latest_tag['str'])
         sys.exit(0)
 
     submodules = []
@@ -94,9 +90,9 @@ def print_release_notes(env):
                 submodule['current_tag']['str'], newest_tag['str']))
 
     print('Syncing to previous CRT release {}...'.format(
-        crt_latest_tag['str']))
-    sh.cd(crt_path, quiet=True)
-    sh.exec('git', 'checkout', crt_latest_tag['str'], quiet=True)
+        package_latest_tag['str']))
+    sh.cd(package_path, quiet=True)
+    sh.exec('git', 'checkout', package_latest_tag['str'], quiet=True)
     sh.exec('git', 'submodule', 'update', '--init', quiet=True)
 
     print('Gathering info...')
@@ -133,8 +129,8 @@ def print_release_notes(env):
             print(
                 'https://github.com/awslabs/{}/releases/tag/{}'.format(submodule['name'], tag['str']))
 
-    print('------ CRT changes ------')
-    print(crt_changes)
+    print('------ Package changes ------')
+    print(package_changes)
 
 
 class ReleaseNotes(Action):

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -1,0 +1,141 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import argparse
+import os
+import re
+import sys
+
+from action import Action
+from actions.script import Script
+
+
+def print_release_notes(env):
+    sh = env.shell
+
+    def warn(msg):
+        if args.ignore_warnings:
+            print("[WARNING]", msg)
+        else:
+            sys.exit(msg + "\nrun with --ignore-warnings to proceed anyway")
+
+    def get_all_tags():
+        git_output = sh.exec('git', 'show-ref', '--tags').output
+        tags = []
+        for line in git_output.splitlines():
+            # line looks like: "e18f041a0c8d17189f2eae2a32f16e0a7a3f0f1c refs/tags/v0.5.18"
+            match = re.match(
+                r'([a-f0-9]+) refs/tags/(v([0-9]+)\.([0-9]+)\.([0-9]+))', line)
+            if not match:
+                # skip malformed release tags
+                continue
+            tags.append({
+                'commit': match.group(1),
+                'str': match.group(2),
+                'num_tuple': (int(match.group(3)), int(match.group(4)), int(match.group(5))),
+            })
+        # sort highest version first
+        return sorted(tags, reverse=True, key=lambda tag: tag['num_tuple'])
+
+    def get_tag_for_commit(tags, commit):
+        for tag in tags:
+            if tag['commit'] == commit:
+                return tag
+
+    def get_current_commit():
+        git_output = sh.exec('git', 'rev-parse', 'HEAD').output
+        return git_output.splitlines()[0]
+
+    parser = argparse.ArgumentParser(
+        description="Help gather release notes for CRTs")
+    parser.add_argument('--ignore-warnings',
+                        action='store_true', help="ignore warnings")
+    args = parser.parse_known_args(env.args.args)[0]
+
+    crt_path = sh.cwd()
+    submodules_root_path = os.path.join(crt_path, 'aws-common-runtime')
+    if not os.path.exists(submodules_root_path):
+        sys.exit('Must be run from an "aws-crt-*" dir')
+
+    print('Syncing to latest master...')
+    sh.exec('git', 'checkout', 'master', quiet=True)
+    sh.exec('git', 'pull', quiet=True)
+    sh.exec('git', 'submodule', 'update', '--init', quiet=True)
+
+    print('Gathering info...')
+    crt_tags = get_all_tags()
+    crt_latest_tag = crt_tags[0]
+
+    crt_changes = sh.exec('git', 'log', crt_latest_tag['commit'] + '..').output
+    if not crt_changes:
+        sys.exit('No changes since last release', crt_latest_tag['str'])
+
+    submodules = []
+    submodule_names = sorted(os.listdir(submodules_root_path))
+    for submodule_name in submodule_names:
+        submodule = {'name': submodule_name,
+                     'path': os.path.join(submodules_root_path, submodule_name)}
+        if submodule_name == 's2n' or not os.path.isdir(submodule['path']):
+            continue
+        submodules.append(submodule)
+        sh.cd(submodule['path'])
+        sh.exec('git', 'fetch', quiet=True)
+        submodule['tags'] = get_all_tags()
+        submodule['current_commit'] = get_current_commit()
+        submodule['current_tag'] = get_tag_for_commit(
+            submodule['tags'], submodule['current_commit'])
+        newest_tag = submodule['tags'][0]
+        if submodule['current_tag'] != newest_tag:
+            warn('{} not at newest release: {} < {}'.format(
+                submodule['current_tag']['str'], newest_tag['str']))
+
+    print('Syncing to previous CRT release {}...'.format(
+        crt_latest_tag['str']))
+    sh.cd(crt_path)
+    sh.exec('git', 'checkout', crt_latest_tag['str'], quiet=True)
+    sh.exec('git', 'submodule', 'update', '--init', quiet=True)
+
+    print('Gathering info...')
+    for submodule in submodules:
+        sh.cd(submodule['path'])
+        submodule['prev_commit'] = get_current_commit()
+        submodule['prev_tag'] = get_tag_for_commit(
+            submodule['tags'], submodule['prev_commit'])
+
+    print('Syncing back to latest...')
+    sh.exec('git', 'checkout', 'master', quiet=True)
+    sh.exec('git', 'submodule', 'update', '--init', quiet=True)
+
+    print('------ Submodule changes ------')
+    for submodule in submodules:
+        # Special warning about API breakages
+        major_change = False
+        if submodule['current_tag']['num_tuple'][0] == 0:
+            if submodule['prev_tag']['num_tuple'][1] != submodule['current_tag']['num_tuple'][1]:
+                major_change = True
+        elif submodule['prev_tag']['num_tuple'][0] != submodule['current_tag']['num_tuple'][0]:
+            major_change = True
+        if major_change:
+            print('MAJOR CHANGE: {} {} -> {}'.format(
+                submodule['name'],
+                submodule['prev_tag']['str'],
+                submodule['current_tag']['str']))
+
+        # Link to release notes
+        # We can just dump text because these are a github thing, not a git thing
+        for tag in submodule['tags']:
+            if tag == submodule['prev_tag']:
+                break
+            print(
+                'https://github.com/awslabs/{}/releases/tag/{}'.format(submodule['name'], tag['str']))
+
+    print('------ CRT changes ------')
+    print(crt_changes)
+
+
+class ReleaseNotes(Action):
+    def is_main(self):
+        return True
+
+    def run(self, env):
+        print_release_notes(env)

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -124,7 +124,7 @@ def print_release_notes(env):
                 submodule['current_tag']['str']))
 
         # Link to release notes
-        # We can just dump text because these are a github thing, not a git thing
+        # We can't just dump text because these are a github thing, not a git thing
         for tag in submodule['tags']:
             if tag == submodule['prev_tag']:
                 break

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -70,7 +70,7 @@ def print_release_notes(env):
         print('No changes since last release', package_latest_tag['str'])
         sys.exit(0)
 
-    submodules_root_path = os.path.join(crt_path, 'aws-common-runtime')
+    submodules_root_path = os.path.join(package_path, 'aws-common-runtime')
     if os.path.exists(submodules_root_path):
         submodules = []
         submodule_names = sorted(os.listdir(submodules_root_path))

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -70,26 +70,28 @@ def print_release_notes(env):
         print('No changes since last release', package_latest_tag['str'])
         sys.exit(0)
 
-    submodules = []
-    submodule_names = sorted(os.listdir(submodules_root_path))
-    for submodule_name in submodule_names:
-        submodule = {'name': submodule_name,
-                     'path': os.path.join(submodules_root_path, submodule_name)}
-        if submodule_name == 's2n' or not os.path.isdir(submodule['path']):
-            continue
-        submodules.append(submodule)
-        sh.cd(submodule['path'], quiet=True)
-        sh.exec('git', 'fetch', quiet=True)
-        submodule['tags'] = get_all_tags()
-        submodule['current_commit'] = get_current_commit()
-        submodule['current_tag'] = get_tag_for_commit(
-            submodule['tags'], submodule['current_commit'])
-        newest_tag = submodule['tags'][0]
-        if submodule['current_tag'] != newest_tag:
-            warn('{} not at newest release: {} < {}'.format(
-                submodule['current_tag']['str'], newest_tag['str']))
+    submodules_root_path = os.path.join(crt_path, 'aws-common-runtime')
+    if os.path.exists(submodules_root_path):
+        submodules = []
+        submodule_names = sorted(os.listdir(submodules_root_path))
+        for submodule_name in submodule_names:
+            submodule = {'name': submodule_name,
+                         'path': os.path.join(submodules_root_path, submodule_name)}
+            if submodule_name == 's2n' or not os.path.isdir(submodule['path']):
+                continue
+            submodules.append(submodule)
+            sh.cd(submodule['path'], quiet=True)
+            sh.exec('git', 'fetch', quiet=True)
+            submodule['tags'] = get_all_tags()
+            submodule['current_commit'] = get_current_commit()
+            submodule['current_tag'] = get_tag_for_commit(
+                submodule['tags'], submodule['current_commit'])
+            newest_tag = submodule['tags'][0]
+            if submodule['current_tag'] != newest_tag:
+                warn('{} not at newest release: {} < {}'.format(
+                    submodule['current_tag']['str'], newest_tag['str']))
 
-    print('Syncing to previous CRT release {}...'.format(
+    print('Syncing to previous release {}...'.format(
         package_latest_tag['str']))
     sh.cd(package_path, quiet=True)
     sh.exec('git', 'checkout', package_latest_tag['str'], quiet=True)

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -72,7 +72,7 @@ def print_release_notes(env):
         'git', 'log', crt_latest_tag['commit'] + '..', quiet=True).output
     if not crt_changes:
         print('No changes since last release', crt_latest_tag['str'])
-        sys.exit(1)
+        sys.exit(0)
 
     submodules = []
     submodule_names = sorted(os.listdir(submodules_root_path))


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Sample output:
```
> python3 -m builder release-notes --project=../aws-crt-java            
Probing /etc/system-release
  Amazon Linux release 2 (Karoo)
Host Environment:
  Host: al2 x64
  Target: linux x64
  Compiler: default (version: 7) /usr/bin/gcc
  Available Compilers: gcc 7, clang 7
  Available Projects: 
Found branches: ['release-notes', 'remotes/origin/release-notes']
Working in branch: release-notes
    Found project: aws-crt-java at /local/home/boswej/dev/aws-crt-java
> cd /local/home/boswej/dev/aws-crt-java
Source directory: /local/home/boswej/dev/aws-crt-java
Build directory: /local/home/boswej/dev/aws-crt-java/target/cmake-build
> rm -rf /local/home/boswej/dev/aws-crt-java/target/cmake-build
> mkdir -p /local/home/boswej/dev/aws-crt-java/target/cmake-build
Using Spec:
  Host: al2 x64
  Target: linux x64
  Compiler: default default
> pushenv
Running: ReleaseNotes
Syncing to latest master...
Gathering info...
Syncing to previous release v0.7.0...
Gathering info...
Syncing back to latest...
------ Submodule changes ------
------ Package changes ------
commit d93840e4ae54ca5f4c10a655cea68309d8abd0d7
Author: Bret Ambrose <bretambrose@gmail.com>
Date:   Fri Aug 21 09:34:56 2020 -0700

    Fix mqtt pubsub test with respect to new constraints on any message handler installation (#223)

Finished: ReleaseNotes
> popenv
```