### PR TITLE
`libcrypto_path` variable is now an absolute path.

### DIFF
--- a/builder/imports/libcrypto.py
+++ b/builder/imports/libcrypto.py
@@ -45,7 +45,7 @@ class LibCrypto(Import):
             # If path to libcrypto is going to be relative, it has to be relative to the
             # source directory
             self.prefix = str(Path(install_dir).relative_to(env.source_dir))
-            env.variables['libcrypto_path'] = self.prefix
+            env.variables['libcrypto_path'] = os.path.abspath(self.prefix)
 
         parser = argparse.ArgumentParser()
         parser.add_argument('--libcrypto', default=None)


### PR DESCRIPTION
aws-crt-ruby does not build from the repo root, so a relative path wasn't working out

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
