### PR TITLE
Rebuilding manylinux docker images with python 3.9

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -328,7 +328,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.linux }}:latest
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ steps.release.outputs.release_tag }} swift --version
+        docker run --env GITHUB_REF $DOCKER_IMAGE --entrypoint bash swift --version
 
   sanity-tests-passed:
     name: All Sanity Tests passed

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -328,7 +328,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.linux }}:latest
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF --entrypoint bash $DOCKER_IMAGE swift --version
+        docker run --env GITHUB_REF --entrypoint 'swift --version' $DOCKER_IMAGE
 
   sanity-tests-passed:
     name: All Sanity Tests passed

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -328,7 +328,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.linux }}:latest
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE --entrypoint bash swift --version
+        docker run --env GITHUB_REF --entrypoint bash $DOCKER_IMAGE swift --version
 
   sanity-tests-passed:
     name: All Sanity Tests passed

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -328,7 +328,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.linux }}:latest
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF --entrypoint 'swift --version' $DOCKER_IMAGE
+        docker run --env GITHUB_REF --entrypoint swift $DOCKER_IMAGE --version
 
   sanity-tests-passed:
     name: All Sanity Tests passed

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
             os.makedirs(args.build_dir)
         os.chdir(args.build_dir)
 
-    print('Working in {}'.format(os.cwd()))
+    print('Working in {}'.format(os.getcwd()))
 
     if spec.target == current_os() and spec.arch == current_arch():
         inspect_host(spec)

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -216,6 +216,8 @@ if __name__ == '__main__':
             os.makedirs(args.build_dir)
         os.chdir(args.build_dir)
 
+    print('Working in {}'.format(os.cwd()))
+
     if spec.target == current_os() and spec.arch == current_arch():
         inspect_host(spec)
     if args.command == 'inspect':


### PR DESCRIPTION
Just forcing a rebuild of these docker images will pull the new manylinux bases.

Also fixed swift tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
