### PR TITLE
Update how node is installed on windows CI builds so that it uses 10.16

### DIFF
--- a/builder/imports/nodejs.py
+++ b/builder/imports/nodejs.py
@@ -29,7 +29,10 @@ class NodeJS(Import):
             },
             **kwargs)
         self.url = 'https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh'
-        self.version = '10'
+        if current_os() == 'windows':
+            self.version = '10.16.0'
+        else:
+            self.version = '10'
         self.nvm = 'nvm'
         self.installed = False
 
@@ -62,6 +65,10 @@ class NodeJS(Import):
             node_path = os.path.dirname(result.output)
             sh.setenv('PATH', '{}{}{}'.format(
                 node_path, os.pathsep, sh.getenv('PATH')))
+        else:
+            sh.exec('nvm', 'use', '10.16', check=True)
+            sh.exec('refreshenv', check=True)
+
         sh.exec('node', '--version', check=True)
 
     def install_nvm_choco(self, env):

--- a/builder/imports/nodejs.py
+++ b/builder/imports/nodejs.py
@@ -29,6 +29,8 @@ class NodeJS(Import):
             },
             **kwargs)
         self.url = 'https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh'
+
+        # windows nvm has stopped installing the latest version, so ask for our minspec
         if current_os() == 'windows':
             self.version = '10.16.0'
         else:


### PR DESCRIPTION
Changes to dependencies resulted in node not getting installed properly and when it did get installed it was using the minimum platform (10.0.0) rather than what we need (10.16+)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
