### PR TITLE
refactor project structure

### DIFF
--- a/.github/docker-images/entrypoint.sh
+++ b/.github/docker-images/entrypoint.sh
@@ -8,7 +8,7 @@ version=LATEST
 if [[ "${args[0]}" == "--version="* ]]; then
     version=${args[0]}
     version=$(echo $version | cut -f2 -d=)
-    args=${args[@]:1}
+    args=(${args[@]:1})
 fi
 
 if [ $(echo $version | grep -E '^v[0-9\.]+$') ]; then

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -44,7 +44,9 @@ jobs:
       run: |
         export CHANNEL=${{ steps.tag.outputs.release_tag }}
         mkdir -p build
-        python3 -m zipapp --python="/usr/bin/env python3" --output=build/builder builder
+        mkdir -p staging
+        cp -r builder staging/.
+        python3 -m zipapp --python="/usr/bin/env python3" -m "builder.main:main" --output=build/builder staging
         aws s3 cp build/builder s3://$AWS_S3_BUCKET/channels/$CHANNEL/builder.pyz
 
     - name: Artifact builder

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,9 @@ jobs:
     - name: Package builder to S3
       run: |
         mkdir -p build
-        python3 -m zipapp --python="/usr/bin/env python3" --output=build/builder builder
+        mkdir -p staging
+        cp -r builder staging/.
+        python3 -m zipapp --python="/usr/bin/env python3" -m "builder.main:main" --output=build/builder staging
         aws s3 cp build/builder s3://$AWS_S3_BUCKET/releases/${{ steps.tag.outputs.release_tag }}/builder.pyz
 
     - name: Artifact builder

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -93,46 +93,46 @@ jobs:
         path: .
 
     - name: Sanity Test Run Compat (Unix)
-      if:  matrix.host != 'windows-latest'
+      if:  ! startsWith(matrix.host, 'windows')
       run: |
         ls -al
         zipinfo -1 builder.pyz
         python3 builder.pyz run test --project tests
 
     - name: Sanity Test Action (Unix)
-      if:  matrix.host != 'windows-latest'
+      if:  ! startsWith(matrix.host, 'windows')
       run: |
         python3 builder.pyz test --project tests
 
     - name: Sanity Test Build (Unix)
-      if:  matrix.host != 'windows-latest'
+      if:  ! startsWith(matrix.host, 'windows')
       run: |
         python3 builder.pyz build --project tests
 
     - name: Sanity Test aws-c-common (Unix)
-      if:  matrix.host != 'windows-latest'
+      if: ! startsWith(matrix.host, 'windows')
       run: |
         python3 builder.pyz build --project aws-c-common
 
     - name: Sanity Test Run Compat (Windows)
-      if: matrix.host == 'windows-latest'
+      if: startsWith(matrix.host, 'windows')
       run: |
         choco install --no-progress vswhere
         python builder.pyz run test --project tests
 
     - name: Sanity Test Action (Windows)
-      if: matrix.host == 'windows-latest'
+      if: startsWith(matrix.host, 'windows')
       run: |
         choco install --no-progress vswhere
         python builder.pyz test --project tests
 
     - name: Sanity Test Build (Windows)
-      if: matrix.host == 'windows-latest'
+      if: startsWith(matrix.host, 'windows')
       run: |
         python builder.pyz build --project tests
 
     - name: Sanity Test aws-c-common (Windows)
-      if: matrix.host == 'windows-latest'
+      if: startsWith(matrix.host, 'windows')
       run: |
         python builder.pyz build --project aws-c-common
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -77,6 +77,7 @@ jobs:
   sanity_test:
     name: Sanity Test
     strategy:
+      fail-fast: false
       matrix:
         host: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2019]
     needs: package

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -192,6 +192,7 @@ jobs:
     needs: [package, sanity_test]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc-8, clang-9]
         std: [c++11, c++14, c++17, c++2a]

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -93,24 +93,24 @@ jobs:
         path: .
 
     - name: Sanity Test Run Compat (Unix)
-      if:  ! startsWith(matrix.host, 'windows')
+      if:  ${{ !startsWith(matrix.host, 'windows') }}
       run: |
         ls -al
         zipinfo -1 builder.pyz
         python3 builder.pyz run test --project tests
 
     - name: Sanity Test Action (Unix)
-      if:  ! startsWith(matrix.host, 'windows')
+      if: ${{ !startsWith(matrix.host, 'windows') }}
       run: |
         python3 builder.pyz test --project tests
 
     - name: Sanity Test Build (Unix)
-      if:  ! startsWith(matrix.host, 'windows')
+      if:  ${{ !startsWith(matrix.host, 'windows') }}
       run: |
         python3 builder.pyz build --project tests
 
     - name: Sanity Test aws-c-common (Unix)
-      if: ! startsWith(matrix.host, 'windows')
+      if: ${{ !startsWith(matrix.host, 'windows') }}
       run: |
         python3 builder.pyz build --project aws-c-common
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -62,7 +62,9 @@ jobs:
     - name: Package builder to S3
       run: |
         mkdir -p build
-        python3 -m zipapp --python="/usr/bin/env python3" --output=build/builder.pyz builder
+        mkdir -p staging
+        cp -r builder staging/.
+        python3 -m zipapp --python="/usr/bin/env python3" -m "builder.main:main" --output=build/builder staging
         aws s3 cp build/builder.pyz s3://$AWS_S3_BUCKET/channels/${{ steps.tag.outputs.release_tag }}/builder.pyz
         zipinfo -1 build/builder.pyz
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -64,7 +64,7 @@ jobs:
         mkdir -p build
         mkdir -p staging
         cp -r builder staging/.
-        python3 -m zipapp --python="/usr/bin/env python3" -m "builder.main:main" --output=build/builder staging
+        python3 -m zipapp --python="/usr/bin/env python3" -m "builder.main:main" --output=build/builder.pyz staging
         aws s3 cp build/builder.pyz s3://$AWS_S3_BUCKET/channels/${{ steps.tag.outputs.release_tag }}/builder.pyz
         zipinfo -1 build/builder.pyz
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ See builder/data.py for more info/defaults/possible values.
     // * target - the target OS class (linux/windows/macos/android)
     // * arch - the target arch
     // * cwd - the current working directory (affected by --build-dir argument)
-    // * source_dir - The source directory for the project being built
+    // * source_dir - The source directory for the root project. In the case of a single build this is the same as {project_source_dir}. When
+    //                building upstream/downstream projects it refers to the original (root) project source directory.
     // * build_dir - The directory where intermediate build artifacts will be generated (defaults to "{source_dir}/build")
     // * deps_dir - The root directory where dependencies will be installed (defaults to "{build_dir}/deps")
     // * install_dir - The output directory for the build, where final artifacts will be installed (defaults to "{build_dir}/install")
+    // * project_source_dir - The source directory for the project being built
     "variables": {
         "my_project_version": "1.0-dev"
     },

--- a/README.md
+++ b/README.md
@@ -113,10 +113,17 @@ See builder/data.py for more info/defaults/possible values.
     // Additional directories to search to find imports, dependencies, consumers before searching GitHub for them
     "search_dirs": [],
 
+    // environment variables
+    "pre_build_env": {} # environment variable(s) for pre_build_steps
+    "build_env": {} # environment variable(s) for build_steps
+    "post_build_env": {} # environment variable(s) for build_steps
+    "env": {} # environment variable(s) for all build steps. Shorthand for setting same variables in each env
+
     // Steps to run before building. default: []
     "pre_build_steps": [
         "echo '{my_project_version}' > version.txt" // see variables section
     ],
+
     // Steps to build the project. If not specified, CMake will be run on the project's root directory
     // If you want to invoke the default build as one of your steps, simply use "build" as that step
     "build_steps": [

--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ arbitrary commands.
 
 ## Developing on builder
 
+Install the package locally to your virtual environment in development mode:
+
+```
+pip install -e .
+```
+
+The `builder.main` console script will be added to your path automatically and changes are reflected "live".
+
 ### Debugging
 When debugging builder locally, use whatever python debugger you wish. You can also feed it the following command line arguments to ease the
 debugging experience:

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ See builder/data.py for more info/defaults/possible values.
     // * target - the target OS class (linux/windows/macos/android)
     // * arch - the target arch
     // * cwd - the current working directory (affected by --build-dir argument)
-    // * source_dir - The source directory for the root project. In the case of a single build this is the same as {project_source_dir}. When
+    // * source_dir - The source directory for the project being built
+    // * root_dir - The source directory for the root project. In the case of a single build this is the same as {source_dir}. When
     //                building upstream/downstream projects it refers to the original (root) project source directory.
     // * build_dir - The directory where intermediate build artifacts will be generated (defaults to "{source_dir}/build")
     // * deps_dir - The root directory where dependencies will be installed (defaults to "{build_dir}/deps")
     // * install_dir - The output directory for the build, where final artifacts will be installed (defaults to "{build_dir}/install")
-    // * project_source_dir - The source directory for the project being built
     "variables": {
         "my_project_version": "1.0-dev"
     },

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -1,30 +1,28 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
-
-from __future__ import print_function
 import argparse
 import os
 import re
 import sys
 
 # If this is running locally for debugging, we need to add the current directory, when packaged this is a non-issue
-sys.path.append(os.path.abspath(os.path.dirname(__file__)))  # nopep8
+# sys.path.append(os.path.abspath(os.path.dirname(__file__)))  # nopep8
 
-from core.spec import BuildSpec
-from actions.script import Script
-from actions.install import InstallPackages, InstallCompiler
-from actions.git import DownloadDependencies
-from actions.mirror import Mirror
-from actions.release import ReleaseNotes
-from core.env import Env
-from core.project import Project
-from core.scripts import Scripts
-from core.toolchain import Toolchain
-from core.host import current_os, current_host, current_arch, current_platform, normalize_target
-import core.data as data
+from builder.core.spec import BuildSpec
+from builder.actions.script import Script
+from builder.actions.install import InstallPackages, InstallCompiler
+from builder.actions.git import DownloadDependencies
+from builder.actions.mirror import Mirror
+from builder.actions.release import ReleaseNotes
+from builder.core.env import Env
+from builder.core.project import Project
+from builder.core.scripts import Scripts
+from builder.core.toolchain import Toolchain
+from builder.core.host import current_os, current_host, current_arch, current_platform, normalize_target
+import builder.core.data as data
 
-import core.api  # force API to load and expose the virtual module
-import imports  # load up all known import classes
+import builder.core.api  # force API to load and expose the virtual module
+import builder.imports  # load up all known import classes
 
 
 ########################################################################################################################

--- a/builder/actions/__init__.py
+++ b/builder/actions/__init__.py
@@ -1,7 +1,0 @@
-# load up all subclasses of Action such that Scripts.load() finds them
-from builder.actions.script import Script
-from builder.actions.install import InstallPackages, InstallCompiler
-from builder.actions.git import DownloadDependencies
-from builder.actions.mirror import Mirror
-from builder.actions.release import ReleaseNotes
-from builder.actions.cmake import CMakeBuild, CTestRun

--- a/builder/actions/__init__.py
+++ b/builder/actions/__init__.py
@@ -1,0 +1,7 @@
+# load up all subclasses of Action such that Scripts.load() finds them
+from builder.actions.script import Script
+from builder.actions.install import InstallPackages, InstallCompiler
+from builder.actions.git import DownloadDependencies
+from builder.actions.mirror import Mirror
+from builder.actions.release import ReleaseNotes
+from builder.actions.cmake import CMakeBuild, CTestRun

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -12,19 +12,18 @@ def _project_dirs(env, project):
     if not project.resolved():
         print('Project is not resolved: {}'.format(project.name))
 
+    source_dir = str(Path(project.path).relative_to(env.source_dir))
+    build_dir = str(Path(os.path.join(env.build_dir, project.name)).relative_to(env.source_dir))
+
     # cross compiles are effectively chrooted to the source_dir, normal builds need absolute paths
     # or cmake gets lost because it wants directories relative to source
     if env.toolchain.cross_compile:
         # all dirs used should be relative to env.source_dir, as this is where the cross
         # compilation will be mounting to do its work
         install_dir = str(Path(env.install_dir).relative_to(env.source_dir))
-        source_dir = str(Path(project.path).relative_to(env.source_dir))
-        build_dir = str(
-            Path(os.path.join(env.build_dir, project.name)).relative_to(env.source_dir))
     else:
         install_dir = env.install_dir
-        source_dir = project.path
-        build_dir = os.path.join(env.build_dir, project.name)
+
     return source_dir, build_dir, install_dir
 
 

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -4,8 +4,8 @@
 import os
 from pathlib import Path
 
-from core.action import Action
-from core.toolchain import Toolchain
+from builder.core.action import Action
+from builder.core.toolchain import Toolchain
 
 
 def _project_dirs(env, project):

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -8,21 +8,23 @@ from core.action import Action
 from core.toolchain import Toolchain
 
 
-# All dirs used should be relative to env.source_dir, as this is where the cross
-# compilation will be mounting to do its work
 def _project_dirs(env, project):
     if not project.resolved():
         print('Project is not resolved: {}'.format(project.name))
 
-    source_dir = str(Path(project.path).relative_to(env.source_dir))
-    build_dir = str(
-        Path(os.path.join(env.build_dir, project.name)).relative_to(env.source_dir))
     # cross compiles are effectively chrooted to the source_dir, normal builds need absolute paths
     # or cmake gets lost because it wants directories relative to source
     if env.toolchain.cross_compile:
+        # all dirs used should be relative to env.source_dir, as this is where the cross
+        # compilation will be mounting to do its work
         install_dir = str(Path(env.install_dir).relative_to(env.source_dir))
+        source_dir = str(Path(project.path).relative_to(env.source_dir))
+        build_dir = str(
+            Path(os.path.join(env.build_dir, project.name)).relative_to(env.source_dir))
     else:
         install_dir = env.install_dir
+        source_dir = project.path
+        build_dir = os.path.join(env.build_dir, project.name)
     return source_dir, build_dir, install_dir
 
 

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -12,15 +12,15 @@ def _project_dirs(env, project):
     if not project.resolved():
         print('Project is not resolved: {}'.format(project.name))
 
-    source_dir = str(Path(project.path).relative_to(env.source_dir))
-    build_dir = str(Path(os.path.join(env.build_dir, project.name)).relative_to(env.source_dir))
+    source_dir = str(Path(project.path).relative_to(env.root_dir))
+    build_dir = str(Path(os.path.join(env.build_dir, project.name)).relative_to(env.root_dir))
 
     # cross compiles are effectively chrooted to the source_dir, normal builds need absolute paths
     # or cmake gets lost because it wants directories relative to source
     if env.toolchain.cross_compile:
         # all dirs used should be relative to env.source_dir, as this is where the cross
         # compilation will be mounting to do its work
-        install_dir = str(Path(env.install_dir).relative_to(env.source_dir))
+        install_dir = str(Path(env.install_dir).relative_to(env.root_dir))
     else:
         install_dir = env.install_dir
 

--- a/builder/actions/git.py
+++ b/builder/actions/git.py
@@ -29,7 +29,7 @@ class DownloadSource(Action):
                 self.path, always=True, retries=3)
         sh.pushd(self.path)
         try:
-            sh.exec("git", "checkout", self.branch, always=True, quiet=True)
+            sh.exec("git", "checkout", self.branch, always=True, quiet=True, check=True)
             print('Switched to branch {}'.format(self.branch))
         except:
             print("Project {} does not have a branch named {}, using main".format(

--- a/builder/actions/git.py
+++ b/builder/actions/git.py
@@ -17,7 +17,7 @@ class DownloadSource(Action):
 
     def run(self, env):
         if self.project.path:
-            print('Project {} already exists on disk'.format(project.name))
+            print('Project {} already exists on disk'.format(self.project.name))
             return
 
         sh = env.shell
@@ -68,9 +68,8 @@ class DownloadDependencies(Action):
                 if dep_proj.path:
                     continue
 
-                dep_branch = getattr(dep, 'revision', branch)
-                DownloadSource(
-                    project=dep_proj, branch=dep_branch, path=env.deps_dir).run(env)
+                dep_branch = branch if dep.revision is None else dep.revision
+                DownloadSource(project=dep_proj, branch=dep_branch, path=env.deps_dir).run(env)
 
                 # grab updated project, collect transitive dependencies/consumers
                 dep_proj = Project.find_project(dep.name)

--- a/builder/actions/git.py
+++ b/builder/actions/git.py
@@ -29,7 +29,8 @@ class DownloadSource(Action):
                 self.path, always=True, retries=3)
         sh.pushd(self.path)
         try:
-            sh.exec("git", "checkout", self.branch, always=True, quiet=True, check=True)
+            sh.exec("git", "checkout", self.branch,
+                    always=True, quiet=True, check=True)
             print('Switched to branch {}'.format(self.branch))
         except:
             print("Project {} does not have a branch named {}, using main".format(

--- a/builder/actions/git.py
+++ b/builder/actions/git.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import os
-from core.action import Action
-from core.project import Project
+from builder.core.action import Action
+from builder.core.project import Project
 
 
 class DownloadSource(Action):

--- a/builder/actions/install.py
+++ b/builder/actions/install.py
@@ -9,11 +9,11 @@ import sys
 from pathlib import Path
 from functools import partial
 
-from core.action import Action
-from core.host import current_os, package_tool
-from actions.script import Script
-from core.toolchain import Toolchain
-from core.util import UniqueList
+from builder.core.action import Action
+from builder.core.host import current_os, package_tool
+from builder.actions.script import Script
+from builder.core.toolchain import Toolchain
+from builder.core.util import UniqueList
 
 
 def set_dryrun(dryrun, env):

--- a/builder/actions/mirror.py
+++ b/builder/actions/mirror.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import os
-from core.action import Action
-from core.project import Import
+from builder.core.action import Action
+from builder.core.project import Import
 
 
 class Mirror(Action):

--- a/builder/actions/release.py
+++ b/builder/actions/release.py
@@ -6,8 +6,8 @@ import os
 import re
 import sys
 
-from core.action import Action
-from actions.script import Script
+from builder.core.action import Action
+from builder.actions.script import Script
 
 
 def print_release_notes(env):

--- a/builder/actions/script.py
+++ b/builder/actions/script.py
@@ -22,8 +22,7 @@ class Script(Action):
             if cmd_type == str:
                 cmd = replace_variables(cmd, env.config['variables'])
             elif cmd_type == list:
-                cmd = [replace_variables(
-                    sub, env.config['variables']) for sub in cmd]
+                cmd = [replace_variables(sub, env.config['variables']) for sub in cmd]
             return cmd
 
         # Interpolate any variables

--- a/builder/actions/script.py
+++ b/builder/actions/script.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import sys
-from core.action import Action
-from core.scripts import Scripts
-from core.util import replace_variables, to_list
+from builder.core.action import Action
+from builder.core.scripts import Scripts
+from builder.core.util import replace_variables, to_list
 
 
 class Script(Action):

--- a/builder/core/api.py
+++ b/builder/core/api.py
@@ -1,19 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from .vmod import VirtualModule
-from .shell import Shell
-from .env import Env
-from .action import Action
-from .scripts import Scripts
-from .project import Project, Import
-from actions.cmake import CMakeBuild, CTestRun
-from actions.git import DownloadSource, DownloadDependencies
-from actions.install import InstallPackages, InstallCompiler
-from actions.script import Script
-from .toolchain import Toolchain
-from . import host
-from . import util
+from builder.core.vmod import VirtualModule
+from builder.core.shell import Shell
+from builder.core.env import Env
+from builder.core.action import Action
+from builder.core.scripts import Scripts
+from builder.core.project import Project, Import
+from builder.actions.cmake import CMakeBuild, CTestRun
+from builder.actions.git import DownloadSource, DownloadDependencies
+from builder.actions.install import InstallPackages, InstallCompiler
+from builder.actions.script import Script
+from builder.core.toolchain import Toolchain
+from builder.core import host
+from builder.core import util
 
 
 class Host(object):

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -29,7 +29,7 @@ KEYS = {
     'build_dir': 'build',
     'deps_dir': '{build_dir}/deps',
     'install_dir': '{build_dir}/install',
-    'env': {}, # environment variables global for all steps
+    'env': {},  # environment variables global for all steps
     'build_env': {},  # environment variables to set before starting build
     'pre_build_env': {},
     'pre_build_steps': [],  # steps to run before build

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from enum import Enum
-from .util import dict_alias
+from builder.core.util import dict_alias
 
 ########################################################################################################################
 # DATA DEFINITIONS

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -29,6 +29,7 @@ KEYS = {
     'build_dir': 'build',
     'deps_dir': '{build_dir}/deps',
     'install_dir': '{build_dir}/install',
+    'env': {}, # environment variables global for all steps
     'build_env': {},  # environment variables to set before starting build
     'pre_build_env': {},
     'pre_build_steps': [],  # steps to run before build

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -125,7 +125,7 @@ HOSTS = {
         # need ld and make and such
         'packages': ['build-essential'],
         'pkg_setup': [
-            'apt-add-repository ppa:ubuntu-toolchain-r/test',
+            'apt-add-repository -y ppa:ubuntu-toolchain-r/test',
         ],
         'pkg_update': 'apt-get -qq update -y',
         'pkg_install': 'apt-get -qq install -y',

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -95,12 +95,12 @@ class Env(object):
         self.config = self.project.get_config(self.spec, self.args.cli_config)
 
         # Once initialized, switch to the source dir before running actions
-        self.source_dir = os.path.abspath(self.project.path)
-        self.variables['source_dir'] = self.source_dir
-        self.shell.cd(self.source_dir)
+        self.root_dir = os.path.abspath(self.project.path)
+        self.variables['root_dir'] = self.root_dir
+        self.shell.cd(self.root_dir)
 
         # Allow these to be overridden by the project, and relative to source_dir if not absolute paths
-        build_dir = self.config.get('build_dir', os.path.join(self.source_dir, 'build'))
+        build_dir = self.config.get('build_dir', os.path.join(self.root_dir, 'build'))
         self.build_dir = os.path.abspath(build_dir)
         self.variables['build_dir'] = self.build_dir
 
@@ -112,12 +112,12 @@ class Env(object):
         self.install_dir = os.path.abspath(install_dir)
         self.variables['install_dir'] = self.install_dir
 
-        print('Source directory: {}'.format(self.source_dir))
+        print('(root) Source directory: {}'.format(self.root_dir))
         print('Build directory: {}'.format(self.build_dir))
 
         Project.search_dirs += [
             self.build_dir,
-            self.source_dir,
+            self.root_dir,
             self.deps_dir,
         ]
 

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -47,7 +47,7 @@ class Env(object):
             if prev:
                 if not isinstance(prev, list):
                     prev = [prev]
-                    val = prev.push(val)
+                    val = prev.append(val)
             self.config[key] = val
 
         # build environment set up

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -146,13 +146,13 @@ class Env(object):
             # and we need to grab the branch being merged from
             # see: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
             branch = github_head_ref
-            print(f"Found github ref for PR from: {branch}")
+            print("Found github ref for PR from: {}".format(branch))
             return branch
         elif github_ref:
             origin_str = "refs/heads/"
             if github_ref.startswith(origin_str):
                 branch = github_ref[len(origin_str):]
-                print(f"Found github ref: {branch}")
+                print("Found github ref: {}".format(branch))
                 return branch
 
         try:

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -5,9 +5,9 @@ import os
 import subprocess
 import sys
 
-from actions.git import DownloadSource
-from .project import Project
-from .shell import Shell
+from builder.actions.git import DownloadSource
+from builder.core.project import Project
+from builder.core.shell import Shell
 
 
 class Env(object):

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -13,7 +13,10 @@ from builder.core.shell import Shell
 class Env(object):
     """ Encapsulates the environment in which the build is running """
 
-    def __init__(self, config={}):
+    def __init__(self, config=None):
+        if config is None:
+            config = {}
+
         # DEFAULTS
         self.dryrun = False  # overwritten by config
 
@@ -76,14 +79,13 @@ class Env(object):
         # it is present on disk
         project = Project.find_project(project_name, hints=hints)
         if not project.path:  # got a ref
-            print('Project {} could not be found locally, downloading'.format(
-                project.name))
-            DownloadSource(
-                project=project, branch=self.branch, path='.').run(self)
+            print('Project {} could not be found locally, downloading'.format(project.name))
+            DownloadSource(project=project, branch=self.branch, path='.').run(self)
+
             # Now that the project is downloaded, look it up again
-            project = Project.find_project(
-                project.name, hints=[os.path.abspath('.')])
+            project = Project.find_project(project.name, hints=[os.path.abspath('.')])
             assert project.resolved()
+
         self.project = project
 
         if not self.project or not self.project.resolved():
@@ -98,18 +100,15 @@ class Env(object):
         self.shell.cd(self.source_dir)
 
         # Allow these to be overridden by the project, and relative to source_dir if not absolute paths
-        build_dir = self.config.get(
-            'build_dir', os.path.join(self.source_dir, 'build'))
+        build_dir = self.config.get('build_dir', os.path.join(self.source_dir, 'build'))
         self.build_dir = os.path.abspath(build_dir)
         self.variables['build_dir'] = self.build_dir
 
-        deps_dir = self.config.get(
-            'deps_dir', os.path.join(self.build_dir, 'deps'))
+        deps_dir = self.config.get('deps_dir', os.path.join(self.build_dir, 'deps'))
         self.deps_dir = os.path.abspath(deps_dir)
         self.variables['deps_dir'] = self.deps_dir
 
-        install_dir = self.config.get(
-            'install_dir', os.path.join(self.build_dir, 'install'))
+        install_dir = self.config.get('install_dir', os.path.join(self.build_dir, 'install'))
         self.install_dir = os.path.abspath(install_dir)
         self.variables['install_dir'] = self.install_dir
 

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -137,12 +137,22 @@ class Env(object):
             print("Found branch:", travis_pr_branch)
             return travis_pr_branch
 
+        # NOTE: head_ref only set for pull_request events
+        # see: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+        github_head_ref = os.environ.get("GITHUB_HEAD_REF")
         github_ref = os.environ.get("GITHUB_REF")
-        if github_ref:
+        if github_head_ref:
+            # if we are triggered from a PR then we are in a detached head state (e.g. `refs/pull/:prNumber/merge`)
+            # and we need to grab the branch being merged from
+            # see: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+            branch = github_head_ref
+            print(f"Found github ref for PR from: {branch}")
+            return branch
+        elif github_ref:
             origin_str = "refs/heads/"
             if github_ref.startswith(origin_str):
                 branch = github_ref[len(origin_str):]
-                print("Found github ref:", branch)
+                print(f"Found github ref: {branch}")
                 return branch
 
         try:

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -112,7 +112,7 @@ class Env(object):
         self.install_dir = os.path.abspath(install_dir)
         self.variables['install_dir'] = self.install_dir
 
-        print('(root) Source directory: {}'.format(self.root_dir))
+        print('Root directory: {}'.format(self.root_dir))
         print('Build directory: {}'.format(self.build_dir))
 
         Project.search_dirs += [

--- a/builder/core/host.py
+++ b/builder/core/host.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from .data import ARCHS, HOSTS, PKG_TOOLS
+from builder.core.data import ARCHS, HOSTS, PKG_TOOLS
 
 import os
 import re

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -232,11 +232,7 @@ def _build_project(project, env):
     children += to_list(project.build(env))
     children += to_list(project.post_build(env))
     children += to_list(project.install(env))
-    if not isinstance(project, Import):
-        # always build projects from their respective root
-        return [partial(_pushd, project.path), *children, _popd]
-    else:
-        return children
+    return children
 
 
 def _pushenv(project, key, env):
@@ -511,7 +507,7 @@ class Project(object):
             # build consumer tests by default, can be turned off by the root project though
             downstream_ref = next((d for d in self.config.get('downstream', []) if d.name == c.name), {})
             if downstream_ref.config.get('run_tests', True):
-                build_consumers += [partial(_pushd, c.path), *to_list(c.test(env)), _popd]
+                build_consumers += to_list(c.test(env))
         if len(build_consumers) == 0:
             return None
         return Script(build_consumers, name='build consumers of {}'.format(self.name))

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -488,7 +488,7 @@ class Project(object):
             downstream_ref = next((d for d in self.config.get(
                 'downstream', []) if d.name == c.name), {})
             if getattr(downstream_ref, 'run_tests', True):
-                build_consumers += to_list(c.test(env))
+                build_consumers += [partial(_pushd, c.path), *to_list(c.test(env)), _popd]
         if len(build_consumers) == 0:
             return None
         return Script(build_consumers, name='build consumers of {}'.format(self.name))

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -222,8 +222,11 @@ def _build_project(project, env):
     children += to_list(project.build(env))
     children += to_list(project.post_build(env))
     children += to_list(project.install(env))
-    # always build projects from their respective root
-    return [partial(_pushd, project.path), *children, _popd]
+    if not isinstance(project, Import):
+        # always build projects from their respective root
+        return [partial(_pushd, project.path), *children, _popd]
+    else:
+        return children
 
 
 def _pushenv(project, key, env):

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -494,7 +494,7 @@ class Project(object):
         return Script(build_consumers, name='build consumers of {}'.format(self.name))
 
     def post_build(self, env):
-        steps = env.config.get('post_build_steps', [])
+        steps = self.config.get('post_build_steps', [])
         if len(steps) == 0:
             return None
         steps = [

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -222,7 +222,8 @@ def _build_project(project, env):
     children += to_list(project.build(env))
     children += to_list(project.post_build(env))
     children += to_list(project.install(env))
-    return children
+    # always build projects from their respective root
+    return [partial(_pushd, project.path), *children, _popd]
 
 
 def _pushenv(project, key, env):
@@ -234,6 +235,13 @@ def _pushenv(project, key, env):
 def _popenv(env):
     env.shell.popenv()
 
+
+def _pushd(path, env):
+    env.shell.pushd(path)
+
+
+def _popd(env):
+    env.shell.popd()
 
 # convert ProjectReference -> Project
 def _resolve_projects(refs):

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -446,7 +446,7 @@ class Project(object):
         if self.resolved():
             # replace project specific variables now that we can
             replacements = {
-                "project_source_dir": self.path,
+                "source_dir": self.path,
             }
             # FIXME - this shouldn't have to happen here, ideally it happens in Script but
             # script doesn't have access to per/project data, only env.variables which only come

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -7,12 +7,12 @@ import glob
 import os
 import sys
 
-from .data import *
-from .host import current_os, package_tool
-from .scripts import Scripts
-from .util import replace_variables, merge_unique_attrs, to_list, tree_transform, isnamedtuple, UniqueList
-from actions.cmake import CMakeBuild, CTestRun
-from actions.script import Script
+from builder.core.data import *
+from builder.core.host import current_os, package_tool
+from builder.core.scripts import Scripts
+from builder.core.util import replace_variables, merge_unique_attrs, to_list, tree_transform, isnamedtuple, UniqueList
+from builder.actions.cmake import CMakeBuild, CTestRun
+from builder.actions.script import Script
 
 
 def looks_like_code(path):
@@ -251,8 +251,6 @@ def _popd(env):
     env.shell.popd()
 
 # convert ProjectReference -> Project
-
-
 def _resolve_projects(refs):
     projects = UniqueList()
     for r in refs:

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -228,6 +228,10 @@ def _build_project(project, env):
 
 def _pushenv(project, key, env):
     env.shell.pushenv()
+    # set project env defaults
+    for var, value in project.config.get('env', {}).items():
+        env.shell.setenv(var, value)
+    # specific env defaults
     for var, value in project.config.get(key, {}).items():
         env.shell.setenv(var, value)
 

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -248,6 +248,8 @@ def _popd(env):
     env.shell.popd()
 
 # convert ProjectReference -> Project
+
+
 def _resolve_projects(refs):
     projects = UniqueList()
     for r in refs:
@@ -424,20 +426,29 @@ class Project(object):
             dep_steps = _build_project(d, env)
 
             if dep_steps:
-                build_deps += [Script(dep_steps, name='build {}'.format(d.name))]
+                build_deps += [Script(dep_steps,
+                                      name='build {}'.format(d.name))]
 
             # allow root project to register additional pre/post build steps that run before or after the dependency is built
-            upstream = next((x for x in self.config.get('upstream', []) if x.name == d.name), None)
+            upstream = next((x for x in self.config.get(
+                'upstream', []) if x.name == d.name), None)
             if upstream and dep_steps:
-                upstream_pre_build_steps = getattr(upstream, 'pre_build_steps', None)
+                upstream_pre_build_steps = getattr(
+                    upstream, 'pre_build_steps', None)
                 if upstream_pre_build_steps:
-                    upstream_pre_build_steps = [partial(_pushd, d.path), *upstream_pre_build_steps, _popd]
-                    build_deps = [Script(upstream_pre_build_steps, name='{}::pre-build::{}'.format(self.name, upstream.name))] + build_deps
+                    upstream_pre_build_steps = [
+                        partial(_pushd, d.path), *upstream_pre_build_steps, _popd]
+                    build_deps = [Script(upstream_pre_build_steps, name='{}::pre-build::{}'.format(
+                        self.name, upstream.name))] + build_deps
 
-                upstream_post_build_steps = getattr(upstream, 'post_build_steps', None)
+                upstream_post_build_steps = getattr(
+                    upstream, 'post_build_steps', None)
                 if upstream_post_build_steps:
-                    upstream_post_build_steps = [partial(_pushd, d.path), *upstream_post_build_steps, _popd]
-                    build_deps = build_deps + [Script(upstream_post_build_steps, name='{}::post-build::{}'.format(self.name, upstream.name))]
+                    upstream_post_build_steps = [
+                        partial(_pushd, d.path), *upstream_post_build_steps, _popd]
+                    build_deps = build_deps + \
+                        [Script(upstream_post_build_steps,
+                                name='{}::post-build::{}'.format(self.name, upstream.name))]
 
         if build_deps:
             build_deps = [Script(build_deps, name='build dependencies')]

--- a/builder/core/scripts.py
+++ b/builder/core/scripts.py
@@ -18,11 +18,11 @@ def _import_dynamic_classes():
     global Action
     global Project
     global Import
-    project = __import__('core').project
+
+    import builder.core.project as project
+    import builder.core.action as action
     Project = getattr(project, 'Project')
     Import = getattr(project, 'Import')
-
-    action = __import__('core').action
     Action = getattr(action, 'Action')
 
 

--- a/builder/core/shell.py
+++ b/builder/core/shell.py
@@ -8,8 +8,8 @@ import subprocess
 import sys
 import tempfile
 
-from .host import current_os
-from . import util
+from builder.core.host import current_os
+from builder.core import util
 
 
 class Shell(object):

--- a/builder/core/spec.py
+++ b/builder/core/spec.py
@@ -4,8 +4,8 @@
 import os
 import sys
 
-from .data import *
-from .host import current_host, current_os, current_arch, normalize_arch
+from builder.core.data import *
+from builder.core.host import current_host, current_os, current_arch, normalize_arch
 
 
 def validate_spec(build_spec):

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -3,9 +3,9 @@
 
 import os
 import re
-from .data import COMPILERS
-from .host import current_os, current_arch, normalize_target, normalize_arch
-from . import util
+from builder.core.data import COMPILERS
+from builder.core.host import current_os, current_arch, normalize_target, normalize_arch
+from builder.core import util
 
 # helpful list of XCode clang output: https://gist.github.com/yamaya/2924292
 

--- a/builder/core/util.py
+++ b/builder/core/util.py
@@ -5,6 +5,7 @@
 import copy
 from collections import namedtuple, UserList
 from collections.abc import Iterable
+from functools import reduce
 import os
 import stat
 from string import Formatter
@@ -68,6 +69,32 @@ def dict_alias(tree, key, alias):
     if key in tree:
         tree[alias] = tree[key]
 
+def _dict_deep_get(dictionary, keys, default=None):
+    """
+    Get the value associated with the composite key if it exists, otherwiser returns the default
+    e.g. _dict_deep_get(d, 'foo.bar.baz') == d['foo']['bar']['baz']
+    """
+    return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
+
+def _attr_deep_get(obj, keys, default=None):
+    """
+    Access the nested attribute value associated with the composite key if it exists, otherwiser returns the default
+    e.g. _attr_deep_get(obj, 'foo.bar.baz') == obj.foo.bar.baz
+    """
+    try:
+        return reduce(getattr, keys.split("."), obj)
+    except AttributeError:
+        return default
+
+def deep_get(target, keys, default=None):
+    """
+    Access the value associated with the composite key if it exists, otherwise return the default.
+    This works on both dictionaries or objec attributes
+    """
+    if isinstance(target, dict):
+        return _dict_deep_get(target, keys, default)
+    else:
+        return _attr_deep_get(target, keys, default)
 
 def tree_transform(tree, key, fn):
     """ At any level in the tree, if key is found, it will be transformed via fn """

--- a/builder/core/util.py
+++ b/builder/core/util.py
@@ -69,12 +69,14 @@ def dict_alias(tree, key, alias):
     if key in tree:
         tree[alias] = tree[key]
 
+
 def _dict_deep_get(dictionary, keys, default=None):
     """
     Get the value associated with the composite key if it exists, otherwiser returns the default
     e.g. _dict_deep_get(d, 'foo.bar.baz') == d['foo']['bar']['baz']
     """
     return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
+
 
 def _attr_deep_get(obj, keys, default=None):
     """
@@ -86,6 +88,7 @@ def _attr_deep_get(obj, keys, default=None):
     except AttributeError:
         return default
 
+
 def deep_get(target, keys, default=None):
     """
     Access the value associated with the composite key if it exists, otherwise return the default.
@@ -95,6 +98,7 @@ def deep_get(target, keys, default=None):
         return _dict_deep_get(target, keys, default)
     else:
         return _attr_deep_get(target, keys, default)
+
 
 def tree_transform(tree, key, fn):
     """ At any level in the tree, if key is found, it will be transformed via fn """

--- a/builder/core/util.py
+++ b/builder/core/util.py
@@ -276,8 +276,8 @@ def content_hash(o):
         except:
             return hash(str(o))
 
-    hashes = copy.deepcopy(o)
-    for k, v in hashes.items():
+    hashes = {}
+    for k, v in o.items():
         hashes[k] = content_hash(v)
 
     return hash(tuple(frozenset(sorted(hashes.items()))))
@@ -286,8 +286,10 @@ def content_hash(o):
 class UniqueList(UserList):
     """ A list that only allows unique items to be appended. Items are id'ed by hash via content_hash """
 
-    def __init__(self, items=[]):
+    def __init__(self, items=None):
         super().__init__()
+        if items is None:
+            items = []
         self._hashes = set()
         for item in items:
             self.append(item)
@@ -299,7 +301,7 @@ class UniqueList(UserList):
 
     def __setitem__(self, idx, value):
         hash = content_hash(value)
-        if not hash in self._hashes:
+        if hash not in self._hashes:
             self._hashes.add(hash)
             self.data.__setitem__(idx, value)
 
@@ -311,6 +313,6 @@ class UniqueList(UserList):
 
     def append(self, value):
         hash = content_hash(value)
-        if not hash in self._hashes:
+        if hash not in self._hashes:
             self._hashes.add(hash)
             self.data.append(value)

--- a/builder/imports/__init__.py
+++ b/builder/imports/__init__.py
@@ -10,21 +10,21 @@ import sys
 import zipfile
 
 modules = []
-parent_package = None
+# parent_package = None
 try:
     # If running in a zipapp, we have to enumerate the zip app instead of the directory
     with zipfile.ZipFile(sys.argv[0]) as app:
-        parent_package = 'imports'
+        # parent_package = 'builder.imports'
         files = app.namelist()
         for f in files:
-            if re.match(r'imports/[a-zA-Z0-9].+.py', f):
-                modules += ['.' + basename(f)[:-3]]
+            if re.match(r'builder/imports/[a-zA-Z0-9].+.py', f):
+                modules += ['builder.imports.' + basename(f)[:-3]]
 except:
     # Must not be a zipapp, look on disk
-    parent_package = 'builder.imports'
+    # parent_package = 'builder.imports'
     modules = glob.glob(join(dirname(__file__), "*.py"))
-    modules = ['.' + basename(f)[:-3] for f in modules if isfile(f)
+    modules = ['builder.imports.' + basename(f)[:-3] for f in modules if isfile(f)
                and not f.endswith('__init__.py')]
 
 for module in modules:
-    importlib.import_module(module, parent_package)
+    importlib.import_module(module)

--- a/builder/imports/__init__.py
+++ b/builder/imports/__init__.py
@@ -10,7 +10,6 @@ import sys
 import zipfile
 
 modules = []
-# parent_package = None
 try:
     # If running in a zipapp, we have to enumerate the zip app instead of the directory
     with zipfile.ZipFile(sys.argv[0]) as app:
@@ -21,7 +20,6 @@ try:
                 modules += ['builder.imports.' + basename(f)[:-3]]
 except:
     # Must not be a zipapp, look on disk
-    # parent_package = 'builder.imports'
     modules = glob.glob(join(dirname(__file__), "*.py"))
     modules = ['builder.imports.' + basename(f)[:-3] for f in modules if isfile(f)
                and not f.endswith('__init__.py')]

--- a/builder/imports/dockcross.py
+++ b/builder/imports/dockcross.py
@@ -1,8 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.host import current_os
-from core.project import Import
+from builder.core.host import current_os
+from builder.core.project import Import
 
 from pathlib import Path
 import os

--- a/builder/imports/gcc.py
+++ b/builder/imports/gcc.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.host import current_os
-from actions.install import InstallPackages
-from core.project import Import
-from actions.script import Script
-from core.toolchain import Toolchain
-from core.util import UniqueList
+from builder.core.host import current_os
+from builder.actions.install import InstallPackages
+from builder.core.project import Import
+from builder.actions.script import Script
+from builder.core.toolchain import Toolchain
+from builder.core.util import UniqueList
 
 
 class GCC(Import):

--- a/builder/imports/jdk.py
+++ b/builder/imports/jdk.py
@@ -41,8 +41,10 @@ class JDK8(Import):
 
         target = '{}-{}'.format(env.spec.target, env.spec.arch)
 
+        cross_compile = util.deep_get(env, 'toolchain.cross_compile', False)
+
         # If this is a local build, check the local machine
-        if not env.toolchain.cross_compile or target not in URLs:
+        if not cross_compile or target not in URLs:
             javac_path = util.where('javac')
             if javac_path:
                 javac_path = javac_path.replace('/bin/javac', '')
@@ -102,7 +104,7 @@ class JDK8(Import):
 
         # Use absolute path for local, relative for cross-compile
         self.path = jdk_home
-        if env.toolchain.cross_compile:
+        if cross_compile:
             self.path = str(Path(os.path.join(install_dir, jdk_home)
                                  ).relative_to(env.source_dir))
 

--- a/builder/imports/jdk.py
+++ b/builder/imports/jdk.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import tarfile
 import zipfile
 
-from core.fetch import fetch_and_extract, mirror_package
-from core.project import Import
-import core.util as util
+from builder.core.fetch import fetch_and_extract, mirror_package
+from builder.core.project import Import
+import builder.core.util as util
 
 URLs = {
     'linux-armv6': 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u232b09.tar.gz',

--- a/builder/imports/jdk.py
+++ b/builder/imports/jdk.py
@@ -83,7 +83,7 @@ class JDK8(Import):
 
         install_dir = os.path.join(env.deps_dir, self.name.lower())
         # If path is going to be relative, it has to be relative to the source directory
-        self.path = str(Path(install_dir).relative_to(env.source_dir))
+        self.path = str(Path(install_dir).relative_to(env.root_dir))
         print('Installing pre-built JDK binaries for {} to {}'.format(
             target, install_dir))
 
@@ -106,7 +106,7 @@ class JDK8(Import):
         self.path = jdk_home
         if cross_compile:
             self.path = str(Path(os.path.join(install_dir, jdk_home)
-                                 ).relative_to(env.source_dir))
+                                 ).relative_to(env.root_dir))
 
         env.variables['java_home'] = self.path
         self.installed = True

--- a/builder/imports/libcrypto.py
+++ b/builder/imports/libcrypto.py
@@ -42,9 +42,7 @@ class LibCrypto(Import):
             if not self.installed:
                 os.symlink(path, install_dir, True)
                 self.installed = True
-            # If path to libcrypto is going to be relative, it has to be relative to the
-            # source directory
-            self.prefix = str(Path(install_dir).relative_to(env.source_dir))
+            self.prefix = install_dir
             env.variables['libcrypto_path'] = self.prefix
 
         parser = argparse.ArgumentParser()

--- a/builder/imports/libcrypto.py
+++ b/builder/imports/libcrypto.py
@@ -1,9 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.fetch import fetch_and_extract
-from core.host import current_host
-from core.project import Import
+from builder.core.fetch import fetch_and_extract
+from builder.core.host import current_host
+from builder.core.project import Import
 
 import argparse
 import os

--- a/builder/imports/libcrypto.py
+++ b/builder/imports/libcrypto.py
@@ -44,7 +44,7 @@ class LibCrypto(Import):
                 self.installed = True
             # If path to libcrypto is going to be relative, it has to be relative to the
             # source directory
-            self.prefix = str(Path(install_dir).relative_to(env.source_dir))
+            self.prefix = str(Path(install_dir).relative_to(env.root_dir))
             env.variables['libcrypto_path'] = self.prefix
 
         parser = argparse.ArgumentParser()

--- a/builder/imports/libcrypto.py
+++ b/builder/imports/libcrypto.py
@@ -42,7 +42,9 @@ class LibCrypto(Import):
             if not self.installed:
                 os.symlink(path, install_dir, True)
                 self.installed = True
-            self.prefix = install_dir
+            # If path to libcrypto is going to be relative, it has to be relative to the
+            # source directory
+            self.prefix = str(Path(install_dir).relative_to(env.source_dir))
             env.variables['libcrypto_path'] = self.prefix
 
         parser = argparse.ArgumentParser()

--- a/builder/imports/llvm.py
+++ b/builder/imports/llvm.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 
-from core.host import current_os
-from core.project import Import
-from core.toolchain import Toolchain
-from core.util import UniqueList
-from actions.install import InstallPackages
-from actions.script import Script
+from builder.core.host import current_os
+from builder.core.project import Import
+from builder.core.toolchain import Toolchain
+from builder.core.util import UniqueList
+from builder.actions.install import InstallPackages
+from builder.actions.script import Script
 
 import os
 import stat

--- a/builder/imports/msvc.py
+++ b/builder/imports/msvc.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.host import current_os
-from core.project import Import
-from core.toolchain import Toolchain
-from core.util import UniqueList
-from actions.install import InstallPackages
-from actions.script import Script
+from builder.core.host import current_os
+from builder.core.project import Import
+from builder.core.toolchain import Toolchain
+from builder.core.util import UniqueList
+from builder.actions.install import InstallPackages
+from builder.actions.script import Script
 
 
 class MSVC(Import):

--- a/builder/imports/ndk.py
+++ b/builder/imports/ndk.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from urllib.parse import urlparse
 import zipfile
 
-from core.fetch import fetch_and_extract, mirror_package
-from core.project import Import
-from core.util import chmod_exec
+from builder.core.fetch import fetch_and_extract, mirror_package
+from builder.core.project import Import
+from builder.core.util import chmod_exec
 
 
 ANDROID_NDK_VERSION = '16b'

--- a/builder/imports/ndk.py
+++ b/builder/imports/ndk.py
@@ -44,7 +44,7 @@ class NDK(Import):
             env.deps_dir, 'android-ndk-r{}'.format(ANDROID_NDK_VERSION))
         # If path to NDK is going to be relative, it has to be relative to the
         # source directory
-        self.prefix = str(Path(install_dir).relative_to(env.source_dir))
+        self.prefix = str(Path(install_dir).relative_to(env.root_dir))
         # Export ndk_path
         env.variables['ndk_path'] = os.path.join('/work', self.prefix)
         print('Installing NDK r{} to {}'.format(

--- a/builder/imports/nodejs.py
+++ b/builder/imports/nodejs.py
@@ -2,12 +2,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.fetch import fetch_script
-from core.host import current_os
-from core.project import Import
-import core.util as util
-from actions.install import InstallPackages
-from actions.script import Script
+from builder.core.fetch import fetch_script
+from builder.core.host import current_os
+from builder.core.project import Import
+import builder.core.util as util
+from builder.actions.install import InstallPackages
+from builder.actions.script import Script
 
 import stat
 import os

--- a/builder/imports/nodejs.py
+++ b/builder/imports/nodejs.py
@@ -5,6 +5,7 @@
 from core.fetch import fetch_script
 from core.host import current_os
 from core.project import Import
+import core.util as util
 from actions.install import InstallPackages
 from actions.script import Script
 
@@ -39,7 +40,7 @@ class NodeJS(Import):
         self.installed = False
 
     def install(self, env):
-        if self.installed:
+        if self.installed or (util.where('node') and current_os() == 'windows'):
             return
 
         sh = env.shell

--- a/builder/imports/s2n.py
+++ b/builder/imports/s2n.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from core.project import Project, Import
+from builder.core.project import Project, Import
 
 
 config = {

--- a/builder/main.py
+++ b/builder/main.py
@@ -5,15 +5,10 @@ import os
 import re
 import sys
 
-# If this is running locally for debugging, we need to add the current directory, when packaged this is a non-issue
-# sys.path.append(os.path.abspath(os.path.dirname(__file__)))  # nopep8
-
 from builder.core.spec import BuildSpec
 from builder.actions.script import Script
 from builder.actions.install import InstallPackages, InstallCompiler
 from builder.actions.git import DownloadDependencies
-from builder.actions.mirror import Mirror
-from builder.actions.release import ReleaseNotes
 from builder.core.env import Env
 from builder.core.project import Project
 from builder.core.scripts import Scripts
@@ -206,7 +201,7 @@ def parse_args():
     return args, spec
 
 
-if __name__ == '__main__':
+def main():
     args, spec = parse_args()
 
     if args.build_dir != '.':
@@ -260,3 +255,7 @@ if __name__ == '__main__':
     # run a single action, usually local to a project
     else:
         run_action(args.command, env)
+
+
+if __name__ == '__main__':
+    main()

--- a/builder/main.py
+++ b/builder/main.py
@@ -6,9 +6,12 @@ import re
 import sys
 
 from builder.core.spec import BuildSpec
+# load up all subclasses of Action such that Scripts.load() finds them
 from builder.actions.script import Script
 from builder.actions.install import InstallPackages, InstallCompiler
 from builder.actions.git import DownloadDependencies
+from builder.actions.mirror import Mirror
+from builder.actions.release import ReleaseNotes
 from builder.core.env import Env
 from builder.core.project import Project
 from builder.core.scripts import Scripts

--- a/builder/main.py
+++ b/builder/main.py
@@ -157,7 +157,10 @@ def parse_args():
             spec = argv.pop(0)
 
     if not command:
-        print('No command provided, should be [build|inspect|<action-name>]')
+        if '-h' in argv or '--help' in argv:
+            parser.print_help()
+        else:
+            print('No command provided, should be [build|inspect|<action-name>]')
         sys.exit(1)
 
     # pull out any k=v pairs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max_line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ setup(
     name="builder",
     version=version,
     packages=find_packages(),
-    scripts=['builder/*.py'],
+    entry_points={
+        'console_scripts': [
+            'builder = builder.main:main'
+        ]
+    },
     author='AWS SDK Common Runtime Team',
     author_email='aws-sdk-common-runtime@amazon.com',
     project_urls={

--- a/tests/data/lib-1/builder.json
+++ b/tests/data/lib-1/builder.json
@@ -1,11 +1,11 @@
 {
     "name": "lib-1",
     "variables": {
-        "gradlew": "{project_source_dir}/gradlew"
+        "gradlew": "{source_dir}/gradlew"
     },
     "build_steps": [
         "echo \"build lib-1\"",
-        "{project_source_dir}/gradlew"
+        "{source_dir}/gradlew"
     ],
     "post_build_steps": [
         "echo \"post build lib-1\"",

--- a/tests/data/lib-1/builder.json
+++ b/tests/data/lib-1/builder.json
@@ -2,5 +2,8 @@
     "name": "lib-1",
     "build_steps": [
         "echo \"build lib-1\""
+    ],
+    "test_steps": [
+        "echo \"test lib-1\""
     ]
 }

--- a/tests/data/lib-1/builder.json
+++ b/tests/data/lib-1/builder.json
@@ -3,6 +3,9 @@
     "build_steps": [
         "echo \"build lib-1\""
     ],
+    "post_build_steps": [
+        "echo \"post build lib-1\""
+    ],
     "test_steps": [
         "echo \"test lib-1\""
     ]

--- a/tests/data/lib-1/builder.json
+++ b/tests/data/lib-1/builder.json
@@ -1,10 +1,15 @@
 {
     "name": "lib-1",
+    "variables": {
+        "gradlew": "{project_source_dir}/gradlew"
+    },
     "build_steps": [
-        "echo \"build lib-1\""
+        "echo \"build lib-1\"",
+        "{project_source_dir}/gradlew"
     ],
     "post_build_steps": [
-        "echo \"post build lib-1\""
+        "echo \"post build lib-1\"",
+        "{gradlew} postBuildTask"
     ],
     "test_steps": [
         "echo \"test lib-1\""

--- a/tests/data/lib-1/builder.json
+++ b/tests/data/lib-1/builder.json
@@ -1,0 +1,6 @@
+{
+    "name": "lib-1",
+    "build_steps": [
+        "echo \"build lib-1\""
+    ]
+}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -210,3 +210,33 @@ class TestProject(unittest.TestCase):
         spec = mock.Mock(name='MockBuildSpec', spec=BuildSpec, target='macos')
         dependencies = p.get_dependencies(spec)
         self.assertEqual(0, len(dependencies), "dependencies should have filtered upstream with specific target")
+
+    def test_project_source_dir_replaced(self):
+        """project_source_dir variable should be replaced"""
+        config = _test_proj_config.copy()
+        config['upstream'] = [
+            {
+                'name': 'lib-1'
+            }
+        ]
+
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv', config=config)
+        steps = p.pre_build(mock_env)
+        self._assert_step_contains(steps, test_data_dir)
+
+    def test_project_variable_replaced(self):
+        """dependency variables should be replaced"""
+        config = _test_proj_config.copy()
+        config['upstream'] = [
+            {
+                'name': 'lib-1'
+            }
+        ]
+
+        p = Project(**config)
+        m_spec = mock.Mock(name='MockBuildSpec', spec=BuildSpec, target='macos')
+        dependencies = p.get_dependencies(m_spec)
+        m_env = mock.Mock(name='MockEnv', config=config)
+        steps = dependencies[0].post_build(m_env)
+        self._assert_step_contains(steps, "{}/gradlew postBuildTask".format(os.path.join(test_data_dir, "lib-1")))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -60,12 +60,20 @@ def _dump_step(step):
 
 class TestProject(unittest.TestCase):
 
+    def _format_step(self, step):
+        step_stack = []
+        _collect_steps(step_stack, step)
+        return "\n".join(step_stack)
+
     def _assert_step_contains(self, step, name):
         if not _step_exists(step, name):
-            step_stack = []
-            _collect_steps(step_stack, step)
-            steps = "\n".join(step_stack)
-            self.fail(f"{name} not contained in step:\n{steps}")
+            steps = self._format_step(step)
+            self.fail(f"{name} not contained in stack:\n{steps}")
+
+    def _assert_step_not_contains(self, step, name):
+        if _step_exists(step, name):
+            steps = self._format_step(step)
+            self.fail(f"unexpected step {name} found in stack:\n{steps}")
 
     def _assert_step_contains_all(self, step, names):
         for name in names:
@@ -100,7 +108,8 @@ class TestProject(unittest.TestCase):
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
         steps = p.pre_build(mock_env)
-        self._assert_step_contains_all(steps, ['build dependencies', 'build lib-1'])
+        self._assert_step_contains_all(
+            steps, ['build dependencies', 'build lib-1'])
 
     def test_extend_upstream_pre_post_build(self):
         """upstream dependency pre/post build can be extended from root project"""
@@ -116,4 +125,46 @@ class TestProject(unittest.TestCase):
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
         steps = p.pre_build(mock_env)
-        self._assert_step_contains_all(steps, ['root pre-build', 'build lib-1', 'root post-build'])
+        self._assert_step_contains_all(
+            steps, ['root pre-build', 'build lib-1', 'root post-build'])
+
+    def test_default_test_step(self):
+        """downstream tests should build by default"""
+        config = _test_proj_config.copy()
+        p = Project(**config)
+        m_toolchain = mock.Mock(name='mock toolchain', cross_compile=False)
+        mock_env = mock.Mock(name='MockEnv', config=config,
+                             toolchain=m_toolchain)
+        steps = p.test(mock_env)
+        self._assert_step_contains(steps, 'test')
+
+    def test_downstream_tests_build_by_default(self):
+        """downstream tests should build by default"""
+
+        config = _test_proj_config.copy()
+        config['downstream'] = [
+            {
+                'name': 'lib-1'
+            }
+        ]
+
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv', config=config)
+        steps = p.build_consumers(mock_env)
+        self._assert_step_contains_all(steps, ['test lib-1'])
+
+    def test_downstream_tests_do_not_build(self):
+        """downstream tests should not be built if requested"""
+
+        config = _test_proj_config.copy()
+        config['downstream'] = [
+            {
+                'name': 'lib-1',
+                'run_tests': False
+            }
+        ]
+
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv', config=config)
+        steps = p.build_consumers(mock_env)
+        self._assert_step_not_contains(steps, 'test lib-1')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -212,21 +212,7 @@ class TestProject(unittest.TestCase):
         self.assertEqual(0, len(dependencies), "dependencies should have filtered upstream with specific target")
 
     def test_project_source_dir_replaced(self):
-        """project_source_dir variable should be replaced"""
-        config = _test_proj_config.copy()
-        config['upstream'] = [
-            {
-                'name': 'lib-1'
-            }
-        ]
-
-        p = Project(**config)
-        mock_env = mock.Mock(name='MockEnv', config=config)
-        steps = p.pre_build(mock_env)
-        self._assert_step_contains(steps, test_data_dir)
-
-    def test_project_variable_replaced(self):
-        """dependency variables should be replaced"""
+        """project specific dependency variables should be replaced"""
         config = _test_proj_config.copy()
         config['upstream'] = [
             {

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,119 @@
+import unittest
+import unittest.mock as mock
+
+from builder.core.project import Project
+from builder.actions.script import Script
+from builder.core.action import Action
+
+import os
+here = os.path.dirname(os.path.abspath(__file__))
+
+test_data_dir = os.path.join(here, 'data')
+
+# base config -- copy for tests
+_test_proj_config = {
+    'name': 'test-proj',
+    'search_dirs': [test_data_dir],
+    'path': here,
+}
+
+
+def _collect_steps(out, step):
+    """
+    collect the list of steps
+    """
+    if isinstance(step, list):
+        for s in step:
+            _collect_steps(out, s)
+    elif isinstance(step, Script):
+        out.append(str(step))
+        _collect_steps(out, step.commands)
+    else:
+        out.append(str(step))
+
+
+def _fuzzy_find_step(step, name):
+    """
+    attempt to find a step name or value that either matches name or contains name as a fragment
+    """
+    step_stack = []
+    _collect_steps(step_stack, step)
+    for s in step_stack:
+        if s == name or name in s:
+            return s
+    return None
+
+
+def _step_exists(step, name):
+    """
+    test if the step [name] exists in the set of [step]s
+    """
+    return _fuzzy_find_step(step, name) is not None
+
+
+def _dump_step(step):
+    import pprint
+    steps = []
+    _collect_steps(steps, step)
+    pprint.pprint(steps)
+
+
+class TestProject(unittest.TestCase):
+
+    def _assert_step_contains(self, step, name):
+        if not _step_exists(step, name):
+            step_stack = []
+            _collect_steps(step_stack, step)
+            steps = "\n".join(step_stack)
+            self.fail(f"{name} not contained in step:\n{steps}")
+
+    def _assert_step_contains_all(self, step, names):
+        for name in names:
+            self._assert_step_contains(step, name)
+
+    def test_build_defaults(self):
+        """cmake build step should be default when not specified and toolchain exists"""
+        p = Project(**_test_proj_config.copy())
+        mock_env = mock.Mock(name='MockEnv')
+        steps = p.build(mock_env)
+
+        s = _fuzzy_find_step(steps, 'cmake build')
+        self.assertIsNotNone(s)
+
+    def test_override_build_steps(self):
+        """explict build steps take precedence"""
+        config = _test_proj_config.copy()
+        config['build_steps'] = ['foo']
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv')
+        steps = p.build(mock_env)
+        s = _fuzzy_find_step(steps, 'foo')
+        self.assertIsNotNone(s)
+
+    def test_upstream_builds_first(self):
+        """upstream dependencies should be built first"""
+        config = _test_proj_config.copy()
+        config['upstream'] = [
+            {'name': 'lib-1'}
+        ]
+
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv', config=config)
+        steps = p.pre_build(mock_env)
+        self._assert_step_contains_all(steps, ['build dependencies', 'build lib-1'])
+
+    def test_extend_upstream_pre_post_build(self):
+        """upstream dependency pre/post build can be extended from root project"""
+        config = _test_proj_config.copy()
+        config['upstream'] = [
+            {
+                'name': 'lib-1',
+                'pre_build_steps': ['root pre-build'],
+                'post_build_steps': ['root post-build']
+            }
+        ]
+
+        p = Project(**config)
+        mock_env = mock.Mock(name='MockEnv', config=config)
+        steps = p.pre_build(mock_env)
+        self._assert_step_contains_all(steps, ['root pre-build', 'build lib-1', 'root post-build'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,71 @@
+import unittest
+import builder.core.util as utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_deep_get_dict(self):
+        """test deep_get for dictionary types"""
+        d = {
+            'foo': {
+                'bar': {
+                    'baz': 'quux'
+                }
+            }
+        }
+
+        self.assertEqual('quux', utils.deep_get(d, 'foo.bar.baz'))
+        self.assertEqual(None, utils.deep_get(d, 'foo.bar.qux'))
+
+    def test_deep_get_attr(self):
+        """test deep_get for object attributes"""
+
+        class Foo():
+            pass
+
+        obj = Foo()
+        obj.foo = Foo()
+        obj.foo.bar = Foo()
+        obj.foo.bar.baz = 'quux'
+
+        self.assertEqual('quux', utils.deep_get(obj, 'foo.bar.baz'))
+        self.assertEqual(None, utils.deep_get(obj, 'foo.bar.qux'))
+
+    def test_replace_variables(self):
+        variables = {'x': 'foo', 'y': 'baz'}
+
+        # string
+        self.assertEqual("foo", utils.replace_variables("{x}", variables))
+        self.assertEqual("foo.bar.baz", utils.replace_variables(
+            "{x}.bar.{y}", variables))
+
+        # lists
+        self.assertEqual(["foo", "qux", "baz"], utils.replace_variables(
+            ["{x}", "qux", "{y}"], variables))
+
+        # dict
+        value = {"f": "{x}", "x": "qux", "b": "{y}"}
+        expected = {"f": "foo", "x": "qux", "b": "baz"}
+        self.assertEqual(expected, utils.replace_variables(value, variables))
+
+    def test_list_unique(self):
+        expected = [1, 2, 3]
+        self.assertEqual(expected, utils.list_unique([1, 1, 2, 1, 3, 2, 1, 3]))
+
+    def test_tree_transform(self):
+        tree = {
+            'foo': {
+                'bar': {
+                    'baz': 2
+                }
+            },
+            'baz': 2
+        }
+
+        def fn(x): return x * 2
+        utils.tree_transform(tree, 'qux', fn)
+        self.assertEqual(tree, tree)
+
+        utils.tree_transform(tree, 'baz', fn)
+        self.assertEqual(tree['baz'], 4)
+        self.assertEqual(tree['foo']['bar']['baz'], 4)


### PR DESCRIPTION
*Description of changes:*
* ~(refactor) Execute steps from the working directory of the project the step belongs to (as opposed to running all steps from the root project)~
* ~(feat) Add `pre_build_steps` and `post_build_steps` to `upstream` dependencies. These steps run before/after the upstream project is built.~
* (fix) `JDK8` import when toolchain is not set (i.e. `needs_compiler=false`). (fixes #89)
* (feat) Add `env` key to config that applies to all steps
* (refactor) Structural changes (some of these were brought up in #88)
    * Restructure project imports to work as a normal python package. Before there was a mix of paths used before (e.g. `import core.action` vs `import builder.core.action` as well as `sys.path` manipulation. This can cause all sorts of problems (e.g. `instanceof` checks can fail as it will see a module/symbol as `xyz.foo` instead of `mypackage.xyz.foo`). 
    * Rename cli entrypoint from `__main__.py` to just `main.py`; zipapp allows you to specify a function as an entrypoint and will create the `__main__.py` script for you.
    * Add console script to `setup.py`. Now when you install locally (`pip install .` or `pip install -e .` for development) to your virtualenv it will add `builder` to your path so you can use it as a normal exe.
* (fix) branch checkout swallowing errors and printing out the wrong branch name when it doesn't exist
* (fix) CLI help flag/usage `-h` not working
* (fix) various usages of `env.config` vs `self.config`
    * Fixes `downstream` consumer tests not running
* (fix) determining branch name when executed from Github `pull_request` event/workflow
* (test) Added some basic unit tests we can hopefully build on
* (fix) builder arguments duplicated in `entrypoint.sh` when `--version` is set
* (feat) define `{project_source_dir}` variable which will always be the project being built (`{source_dir}` and `{project_source_dir}` are the same for the "root" project but downstream/upstream projects `{source_dir}` currently refers to the root project `{source_dir}`).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
