### PR TITLE
Removed deprecated set-env calls

### DIFF
--- a/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN python3 -m pip install --upgrade pip setuptools \
+RUN python3 -m pip install setuptools \
     && python3 -m pip install --upgrade awscli \
     && aws --version
 

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN python3 -m pip install --upgrade pip setuptools \
+RUN python3 -m pip install setuptools \
     && python3 -m pip install --upgrade awscli \
     && aws --version
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -65,7 +65,7 @@ jobs:
         context: .github/docker-images/${{ matrix.variant }}
         build_extra_args: --compress=true
 
-    - name: Export ${{ matrix.variant }} image to S3/channels/${{ env.IMAGE_TAG }}
+    - name: Export ${{ matrix.variant }} image to S3/channels/${{ steps.tag.outputs.release_tag }}
       run: |
         export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
         docker save docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.variant }}:$IMAGE_TAG > /tmp/aws-crt-${{ matrix.variant }}-$IMAGE_TAG.tar.gz

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -26,19 +26,6 @@ jobs:
     steps:
     - name: Checkout Sources
       uses: actions/checkout@v1
-    - name: Get release tag
-      uses: ./.github/actions/release-tag
-      id: release
-      with:
-        output: tag
-
-    - run: echo TAG ${{ steps.release.outputs.release_tag }}
-
-    - name: Store release_tag
-      uses: actions/upload-artifact@v1
-      with:
-        name: release_tag
-        path: tag
 
   linux-images:
     name: ${{ matrix.variant }}
@@ -65,17 +52,12 @@ jobs:
     - name: Checkout Sources
       uses: actions/checkout@v1
 
-    - name: Fetch release_tag
-      uses: actions/download-artifact@v1
-      with:
-        name: release_tag
-        path: release_tag
-
-    - name: Export IMAGE_TAG
-      run: echo "::set-env name=IMAGE_TAG::$(cat release_tag/tag)"
+    - name: Get release_tag
+      uses: ./.github/actions/release-tag
+      id: tag
 
     - name: Install entrypoint
-      run: cat .github/docker-images/entrypoint.sh | sed s/version=LATEST/version=$IMAGE_TAG/ > .github/docker-images/${{ matrix.variant }}/entrypoint.sh
+      run: cat .github/docker-images/entrypoint.sh | sed s/version=LATEST/version=${{ steps.tag.outputs.release_tag }}/ > .github/docker-images/${{ matrix.variant }}/entrypoint.sh
 
     - name: Install qemu/docker
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -87,14 +69,15 @@ jobs:
         username: awslabs
         password: ${{ secrets.DOCKER_TOKEN }}
         image_name: awslabs/aws-crt-builder/aws-crt-${{ matrix.variant }}
-        image_tag: ${{ env.IMAGE_TAG }}
+        image_tag: ${{ steps.tag.outputs.release_tag }}
         context: .github/docker-images/${{ matrix.variant }}
         build_extra_args: --compress=true
 
     - name: Export ${{ matrix.variant }} image to S3/channels/${{ env.IMAGE_TAG }}
       run: |
-        docker save docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.variant }}:${{ env.IMAGE_TAG }} > /tmp/aws-crt-${{ matrix.variant }}-${{ env.IMAGE_TAG }}.tar.gz
-        aws s3 cp --no-progress /tmp/aws-crt-${{ matrix.variant }}-${{ env.IMAGE_TAG }}.tar.gz s3://${{env.AWS_S3_BUCKET}}/channels/${{ env.IMAGE_TAG }}/aws-crt-${{ matrix.variant }}.tar.gz
+        export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
+        docker save docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.variant }}:$IMAGE_TAG > /tmp/aws-crt-${{ matrix.variant }}-$IMAGE_TAG.tar.gz
+        aws s3 cp --no-progress /tmp/aws-crt-${{ matrix.variant }}-$IMAGE_TAG.tar.gz s3://${{env.AWS_S3_BUCKET}}/channels/$IMAGE_TAG/aws-crt-${{ matrix.variant }}.tar.gz
 
   ###############################################################################
   # DOWNSTREAM TESTS
@@ -111,14 +94,14 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v1
 
-    - name: Get Release Tag
+    - name: Get release_tag
       uses: ./.github/actions/release-tag
-      id: release
+      id: tag
 
     # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build aws-c-common + consumers
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-        export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-ubuntu-16-x64:${{ steps.release.outputs.release_tag }}
+        export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-ubuntu-16-x64:${{ steps.tag.outputs.release_tag }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ steps.release.outputs.release_tag }} build -p aws-c-common --target=${{ matrix.target }}
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ steps.tag.outputs.release_tag }} build -p aws-c-common --target=${{ matrix.target }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -20,17 +20,9 @@ env:
   AWS_REGION: 'us-east-1'
 
 jobs:
-  tag:
-    name: Artifact release tag
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v1
-
   linux-images:
     name: ${{ matrix.variant }}
     runs-on: ubuntu-latest
-    needs: [tag]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
