### PR TITLE
Improved handling of cli config args.

### DIFF
--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -27,7 +27,6 @@ class Env(object):
                 super().__setitem__(item, value)
                 env._publish_variable(item, value)
         self.variables = Variables()
-        self.config = {}
 
         # OVERRIDES: copy incoming config, overwriting defaults
         for key, val in config.items():
@@ -40,15 +39,6 @@ class Env(object):
         # make sure the shell is initialized
         if not hasattr(self, 'shell'):
             self.shell = Shell(self.dryrun)
-
-        # Default config to whatever is on the command line, fill in later when project is loaded
-        for key, val in self.args.cli_config.items():
-            prev = self.config.get(key)
-            if prev:
-                if not isinstance(prev, list):
-                    prev = [prev]
-                    val = prev.append(val)
-            self.config[key] = val
 
         # build environment set up
         self.launch_dir = os.path.abspath(self.shell.cwd())

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -45,7 +45,6 @@ def _apply_value(obj, key, new_value, apply_before=True):
     if key_type == list:
         # apply the config's value before the existing list
         val = obj[key]
-        new_value = list(new_value)
         if apply_before:
             obj[key] = new_value + val
         else:

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -45,14 +45,11 @@ def _apply_value(obj, key, new_value, apply_before=True):
     if key_type == list:
         # apply the config's value before the existing list
         val = obj[key]
-        if val:
-            new_value = list(new_value)
-            if apply_before:
-                obj[key] = new_value + val
-            else:
-                obj[key] = val + new_value
+        new_value = list(new_value)
+        if apply_before:
+            obj[key] = new_value + val
         else:
-            obj[key] = new_value
+            obj[key] = val + new_value
 
     elif key_type == dict:
         # iterate each element and recursively apply the values
@@ -193,7 +190,11 @@ def produce_config(build_spec, project, overrides=None, **additional_variables):
     if overrides:
         for key, val in overrides.items():
             if key.startswith('!'):
-                new_version[key] = val
+                # re-init and replace current value, obeying type coercion rules
+                key = key[1:]
+                if key in new_version:
+                    new_version[key] = new_version[key].__class__()
+                _apply_value(new_version, key, val)
             else:
                 _apply_value(new_version, key, val)
 


### PR DESCRIPTION
*Issue:*

wanted to pass `cmake_args=-DBUILD_SHARED_LIBS=ON` to builder and it didn't work right

*Description of changes:*

- move all logic for fixing up cli_config to one place
- consult default KEYS to see if it should be a list
- fix bugs when reading in list args
- assume user wants to "!" override a list. Allow "+" for appending to defaults.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
