### PR TITLE
--cmake-extra lets you add extra cmake args to every project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage: ```builder.pyz [build|inspect|<action-name>] [spec] [OPTIONS]```
   * Valid values are anything that you could get from `uname`.lower() - `uname -m`, e.g. linux-x86_64, linux-x64. See targets below.
 * ```--build-dir DIR``` - Make a new directory to do all the build work in, instead of using the current directory
 * ```--dump-config``` - Dumps the resultant config after merging all available options. Useful for debugging your project configuration.
+* ```--cmake-extra``` - Extra cmake config arg applied to all projects. e.g ```--cmake-extra=-DBUILD_SHARED_LIBS=ON```. May be specified multiple times.
 
 
 ### Supported Targets:

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from builder.core.action import Action
 from builder.core.toolchain import Toolchain
+from builder.core.util import UniqueList
 
 
 def _project_dirs(env, project):
@@ -59,7 +60,7 @@ def _build_project(env, project, cmake_extra, build_tests=False):
                 compiler_flags.append(
                     '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), value))
 
-    cmake_args = [
+    cmake_args = UniqueList([
         "-B{}".format(project_build_dir),
         "-H{}".format(project_source_dir),
         # "-Werror=dev",
@@ -70,7 +71,9 @@ def _build_project(env, project, cmake_extra, build_tests=False):
         "-DCMAKE_BUILD_TYPE=" + build_config,
         "-DBUILD_TESTING=" + ("ON" if build_tests else "OFF"),
         *compiler_flags,
-    ]
+    ])
+    # Merging in cmake_args from all upstream projects inevitably leads to duplicate arguments.
+    # Using a UniqueList seems to solve the problem well enough for now.
     cmake_args += project.cmake_args(env)
     cmake_args += cmake_extra
 

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -69,7 +69,9 @@ def _build_project(env, project, build_tests=False):
         "-DCMAKE_BUILD_TYPE=" + build_config,
         "-DBUILD_TESTING=" + ("ON" if build_tests else "OFF"),
         *compiler_flags,
-    ] + project.cmake_args(env)
+    ]
+    cmake_args += project.cmake_args(env)
+    cmake_args += env.args.cmake_extra
 
     # When cross compiling, we must inject the build_env into the cross compile container
     build_env = []

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -456,19 +456,19 @@ COMPILERS = {
             # 2015
             '14': {
                 'cmake_args': [
-                    '-T', 'v140',
+                    '-Tv140',
                 ],
             },
             # 2017
             '15': {
                 'cmake_args': [
-                    '-T', 'v141',
+                    '-Tv141',
                 ],
             },
             # 2019
             '16': {
                 'cmake_args': [
-                    '-T', 'v142',
+                    '-Tv142',
                 ],
             }
         },
@@ -476,12 +476,12 @@ COMPILERS = {
         'architectures': {
             'x86': {
                 'cmake_args': [
-                    '-A', 'Win32',
+                    '-AWin32',
                 ],
             },
             'x64': {
                 'cmake_args': [
-                    '-A', 'x64',
+                    '-Ax64',
                 ],
             },
         },

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -102,6 +102,10 @@ class Env(object):
         self.install_dir = os.path.abspath(install_dir)
         self.variables['install_dir'] = self.install_dir
 
+        # Add install/bin to $PATH, so that downstream tests can find any shared libs we've built
+        install_bin_dir = os.path.abspath(os.path.join(self.install_dir, 'bin'))
+        self.shell.setenv('PATH', self.shell.getenv('PATH') + os.pathsep + install_bin_dir)
+
         print('Root directory: {}'.format(self.root_dir))
         print('Build directory: {}'.format(self.build_dir))
 

--- a/builder/imports/awslc.py
+++ b/builder/imports/awslc.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+from builder.core.project import Project, Import
+
+
+config = {
+    'targets': ['linux', 'android'],
+    'test_steps': [],
+    'build_tests': False,
+}
+
+
+class AWSLCImport(Import):
+    def __init__(self, **kwargs):
+        super().__init__(
+            library=True,
+            config=config,
+            **kwargs)
+
+
+class AWSLCProject(Project):
+    def __init__(self, **kwargs):
+        super().__init__(
+            account='awslabs',
+            config=config,
+            **kwargs)

--- a/builder/main.py
+++ b/builder/main.py
@@ -142,8 +142,9 @@ def parse_args():
     parser.add_argument('--target', type=str, help="The target to cross-compile for (e.g. android-armv7, linux-x86, linux-aarch64)",
                         default='{}-{}'.format(current_os(), current_arch()),
                         choices=data.PLATFORMS.keys())
-    parser.add_argument('--cmake-extra', action='append', help='Extra cmake config arg applied to all projects.' +
-                        ' May be specified multiple times. (e.g "--cmake-extra=-DBUILD_SHARED_LIBS=ON"')
+    parser.add_argument('--cmake-extra', action='append', default=[],
+                        help='Extra cmake config arg applied to all projects. May be specified multiple times. ' +
+                        '(e.g "--cmake-extra=-DBUILD_SHARED_LIBS=ON"')
     parser.add_argument('args', nargs=argparse.REMAINDER)
 
     # hand parse command and spec from within the args given

--- a/builder/main.py
+++ b/builder/main.py
@@ -142,10 +142,6 @@ def parse_args():
     parser.add_argument('--target', type=str, help="The target to cross-compile for (e.g. android-armv7, linux-x86, linux-aarch64)",
                         default='{}-{}'.format(current_os(), current_arch()),
                         choices=data.PLATFORMS.keys())
-    parser.add_argument('--cmake-extra', action='append', default=[],
-                        help='Extra cmake config arg applied to all projects. May be specified multiple times. ' +
-                        '(e.g "--cmake-extra=-DBUILD_SHARED_LIBS=ON"')
-    parser.add_argument('args', nargs=argparse.REMAINDER)
 
     # hand parse command and spec from within the args given
     command = None
@@ -165,8 +161,9 @@ def parse_args():
             print('No command provided, should be [build|inspect|<action-name>]')
         sys.exit(1)
 
-    # parse the args we know, the rest end up in args.args for others to parse
-    args = parser.parse_args(argv)
+    # parse the args we know, put the rest in args.args for others to parse
+    args, extra = parser.parse_known_args(argv)
+    args.args = extra
     args.command = command
     args.spec = args.spec if args.spec else spec
     # Backwards compat for `builder run $action`


### PR DESCRIPTION
The existing `cmake_args` in the config does not affect the building of upstream dependencies

So add new CLI argument we can use like `--cmake-extra=-DBUILD_SHARED_LIBS=ON` and build everything in the tree with a given flag

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
