### PR TITLE
Use cpu-count for parallel builds

### DIFF
--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -90,7 +90,7 @@ def _build_project(env, project, cmake_extra, build_tests=False):
 
     # set parallism via env var (cmake's --parallel CLI option doesn't exist until 3.12)
     if os.environ.get('CMAKE_BUILD_PARALLEL_LEVEL') is None:
-        sh.setenv('CMAKE_BUILD_PARALLEL_LEVEL', os.cpu_count())
+        sh.setenv('CMAKE_BUILD_PARALLEL_LEVEL', str(os.cpu_count()))
 
     # build
     sh.exec(*toolchain.shell_env, "cmake", "--build", project_build_dir, "--config",

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -88,12 +88,13 @@ def _build_project(env, project, cmake_extra, build_tests=False):
     # configure
     sh.exec(*toolchain.shell_env, "cmake", cmake_args, check=True)
 
-    parallel = ["--", "-j"]
-    if toolchain.compiler == 'msvc':
-        parallel = ['--', '-maxcpucount']
+    # set parallism via env var (cmake's --parallel CLI option doesn't exist until 3.12)
+    if os.environ.get('CMAKE_BUILD_PARALLEL_LEVEL') is None:
+        sh.setenv('CMAKE_BUILD_PARALLEL_LEVEL', os.cpu_count())
+
     # build
     sh.exec(*toolchain.shell_env, "cmake", "--build", project_build_dir, "--config",
-            build_config, *parallel, check=True)
+            build_config, check=True)
 
     # install
     sh.exec(*toolchain.shell_env, "cmake", "--build", project_build_dir, "--config",


### PR DESCRIPTION
*Issue:*

GCC builds were freezing when building aws-lc.
We suspected it was due to too much parallelism.
Passing -j to make will do an unlimited amount of parallelism, so stop doing that.

*Description of changes:*

Instead of passing -j through to make which causes unbounded parallelism, use CMAKE_BUILD_PARALLEL_LEVEL=cpu-count

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
