### PR TITLE
fix linux-shared-lib tests

### DIFF
--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -102,9 +102,12 @@ class Env(object):
         self.install_dir = os.path.abspath(install_dir)
         self.variables['install_dir'] = self.install_dir
 
-        # Add install/bin to $PATH, so that downstream tests can find any shared libs we've built
-        install_bin_dir = os.path.abspath(os.path.join(self.install_dir, 'bin'))
-        self.shell.setenv('PATH', self.shell.getenv('PATH') + os.pathsep + install_bin_dir)
+        # modify environment so that downstream tests can find any shared libs we may build
+        if sys.platform == 'win32':
+            self.shell.addpathenv('PATH', os.path.abspath(os.path.join(self.install_dir, 'bin')))
+        else:
+            self.shell.addpathenv('LD_LIBRARY_PATH', os.path.abspath(os.path.join(self.install_dir, 'lib64')))
+            self.shell.addpathenv('LD_LIBRARY_PATH', os.path.abspath(os.path.join(self.install_dir, 'lib')))
 
         print('Root directory: {}'.format(self.root_dir))
         print('Build directory: {}'.format(self.build_dir))

--- a/builder/core/shell.py
+++ b/builder/core/shell.py
@@ -82,6 +82,15 @@ class Shell(object):
         if not self.dryrun:
             os.environ[var] = value
 
+    def addpathenv(self, var, path, **kwargs):
+        """Add a path to an environment variable"""
+        prev = os.getenv(var)
+        if prev:
+            value = prev + os.pathsep + path
+        else:
+            value = path
+        self.setenv(var, value, **kwargs)
+
     def getenv(self, var):
         """ Get an environment variable """
         return os.environ[var]


### PR DESCRIPTION
windows needs `install/bin` added to $PATH so tests can find DLLs
linux needs `install/lib` added to $LD_LIBRARY_PATH so tests can find .so

this cropped up on running aws-c-http's integration tests. which included launching ANOTHER python process that, in turn, launched a another executable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
