### PR TITLE
trivial improvements

### DIFF
--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -108,12 +108,12 @@ def _build_project(env, project, cmake_extra, build_tests=False):
         with open(toolchain.env_file, 'a') as f:
             f.writelines(build_env)
 
-    # configure
-    sh.exec(*toolchain.shell_env, cmake, cmake_args, check=True)
-
     # set parallism via env var (cmake's --parallel CLI option doesn't exist until 3.12)
     if os.environ.get('CMAKE_BUILD_PARALLEL_LEVEL') is None:
         sh.setenv('CMAKE_BUILD_PARALLEL_LEVEL', str(os.cpu_count()))
+
+    # configure
+    sh.exec(*toolchain.shell_env, cmake, cmake_args, check=True)
 
     # build
     sh.exec(*toolchain.shell_env, cmake, "--build", project_build_dir, "--config",

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -597,18 +597,17 @@ class Project(object):
         Items are ordered such that building Projects in the order given should just work.
         """
         # first, gather flat list of deps, in breadth-first order, with duplicates included
-        def _gather_all(project, spec):
-            deps = project.get_dependencies(spec)
-            for dep in deps.copy():
-                deps += _gather_all(dep, spec)
-            return deps
+        deps = [self]
+        i = 0
+        while i < len(deps):
+            deps.extend(deps[i].get_dependencies(spec))
+            i += 1
 
-        all_deps = _gather_all(self, spec)
-        if include_self:
-            all_deps.insert(0, self)
+        if not include_self:
+            deps.pop(0)
 
         # remove duplicates and put everything in proper build-order
-        unique_deps = UniqueList(reversed(all_deps))
+        unique_deps = UniqueList(reversed(deps))
         return unique_deps
 
     def get_consumers(self, spec):

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -596,19 +596,16 @@ class Project(object):
         Gets full tree of dependencies as flat list with duplicates removed.
         Items are ordered such that building Projects in the order given should just work.
         """
-        # first, gather flat list of deps, in breadth-first order, with duplicates included
-        deps = [self]
-        i = 0
-        while i < len(deps):
-            deps.extend(deps[i].get_dependencies(spec))
-            i += 1
 
-        if not include_self:
-            deps.pop(0)
+        # each project inserts dependencies before self
+        def _post_order(project, spec, deps):
+            for dep in project.get_dependencies(spec):
+                _post_order(dep, spec, deps)
+            deps.append(project)
 
-        # remove duplicates and put everything in proper build-order
-        unique_deps = UniqueList(reversed(deps))
-        return unique_deps
+        deps = UniqueList()
+        _post_order(self, spec, deps)
+        return deps
 
     def get_consumers(self, spec):
         """ Gets consumers for a given BuildSpec, filters by target """


### PR DESCRIPTION
- set CMAKE_BUILD_PARALLEL_LEVEL before configuring, to speed up any builds during configure stage (I'm looking at you aws-lc.cmake)
- tweak tree traversal. it wasn't wrong before, but claimed to be a breadth search while it was actually a weird mix of both breadth and depth. now it's post-order traversal, which gets nice results

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
