### PR TITLE
Clang CI Temp Fix (hopefully)

### DIFF
--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -25,13 +25,14 @@ RUN apt-get update -qq \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN python3 -m pip install setuptools
-RUN python3 -m pip install --upgrade pip
 WORKDIR /tmp
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
-RUN unzip awscliv2.zip
-RUN sudo aws/install
-RUN aws --version
+
+RUN python3 -m pip install setuptools \
+    && python3 -m pip install --upgrade pip \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && sudo aws/install \
+    && aws --version
 
 ###############################################################################
 # Install pre-built CMake

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -10,6 +10,7 @@ RUN apt-get update -qq \
     git \
     curl \
     sudo \
+    unzip \
     # Python
     python3 \
     python3-dev \
@@ -24,14 +25,17 @@ RUN apt-get update -qq \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN python3 -m pip install setuptools \
-    && python3 -m pip install --upgrade awscli \
-    && aws --version
+RUN python3 -m pip install setuptools
+RUN python3 -m pip install --upgrade pip
+WORKDIR /tmp
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+RUN unzip awscliv2.zip
+RUN sudo aws/install
+RUN aws --version
 
 ###############################################################################
 # Install pre-built CMake
 ###############################################################################
-WORKDIR /tmp
 RUN curl -sSL https://d19elf31gohf1l.cloudfront.net/_binaries/cmake/cmake-3.13-manylinux1-x64.tar.gz -o cmake.tar.gz \
     && tar xvzf cmake.tar.gz -C /usr/local \
     && cmake --version \


### PR DESCRIPTION
Temporary workaround for old clang fetch failures by switching from ubuntu 16 to 18 as the base image.  Yes the container is still called ubuntu-16-x64 despite this change because updating every single ci.yml sounds like misery for a temp change (until we get  docker images with clang included available)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
