### PR TITLE
add ssl packages to swift images for ci checks

### DIFF
--- a/.github/docker-images/swift-5-al2-x64/Dockerfile
+++ b/.github/docker-images/swift-5-al2-x64/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y update \
     make \
     cmake3 \
     gcc-c++ \
+    openssl-devel \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && ln -s /usr/bin/cmake3 /usr/bin/cmake \

--- a/.github/docker-images/swift-5-centos-x64/Dockerfile
+++ b/.github/docker-images/swift-5-centos-x64/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y update \
     make \
     cmake \
     cmake3 \
+    openssl-devel \
     gcc-c++ \
     && yum clean all \
     && rm -rf /var/cache/yum 

--- a/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update -qq \
     python3-pip \
     build-essential \
     # For PPAs
+    openssl \
+    libssl-dev \
     software-properties-common \
     apt-transport-https \
     ca-certificates \

--- a/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/swift-5-ubuntu-16-x64/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update -qq \
     python3-pip \
     build-essential \
     # For PPAs
-    openssl \
     libssl-dev \
     software-properties-common \
     apt-transport-https \


### PR DESCRIPTION
*Description of changes:* SSL Packages missing on swift images needed for proper ci checks in aws-crt-swift.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
