### PR TITLE
Disable Go for Android Build to support AWS-LC.

### DIFF
--- a/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
+++ b/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
@@ -74,6 +74,7 @@ compile_flags="-fPIC -g"
 libcrypto_version=1.1.1
 android_ndk_version=16b
 android_api_version=19
+go_version=1.16.3
 
 # Create a .dockcross bootstrap file for the dockcross container, which is its init script
 # Note that commands going into dockcross need to be quoted based on which shell you want the expansion done by. If the
@@ -92,6 +93,8 @@ function build_android {
     if [ ! -e android-ndk-r${android_ndk_version} ]; then
         cp -r /tmp/openssl-${os}-${arch}/android-ndk-r${android_ndk_version} android-ndk-r${android_ndk_version}
     fi
+    curl -sSL -o go.tar.gz  https://golang.org/dl/go${go_version}.linux-amd64.tar.gz
+    tar -C /work -xzf go${go_version}.linux-amd64.tar.gz
     # configure the android SDK via .dockcross config
     # No interpolation, expand in the dockcross shell
     (cat <<- BOOT
@@ -102,6 +105,7 @@ export ANDROID_NDK_HOME=/work/android-ndk-r${android_ndk_version}
 export PACKAGE_NAME=libcrypto-${libcrypto_version}-${os}-${arch}.tar.gz
 export LIBCRYPTO_PLATFORM=${openssl_target}
 export COMPILE_FLAGS=${compile_flags}
+export PATH=/work/go/bin:$PATH
 BOOT
     )>> .dockcross
     # No interpolation, eval in dockcross shell

--- a/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
+++ b/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
@@ -99,7 +99,6 @@ function build_android {
 set -ex
 
 export ANDROID_NDK_HOME=/work/android-ndk-r${android_ndk_version}
-export CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
 export PACKAGE_NAME=libcrypto-${libcrypto_version}-${os}-${arch}.tar.gz
 export LIBCRYPTO_PLATFORM=${openssl_target}
 export COMPILE_FLAGS=${compile_flags}

--- a/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
+++ b/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
@@ -99,6 +99,7 @@ function build_android {
 set -ex
 
 export ANDROID_NDK_HOME=/work/android-ndk-r${android_ndk_version}
+export CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
 export PACKAGE_NAME=libcrypto-${libcrypto_version}-${os}-${arch}.tar.gz
 export LIBCRYPTO_PLATFORM=${openssl_target}
 export COMPILE_FLAGS=${compile_flags}

--- a/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
+++ b/.github/docker-images/crossbuild_libcrypto_1.1.1.sh
@@ -74,7 +74,6 @@ compile_flags="-fPIC -g"
 libcrypto_version=1.1.1
 android_ndk_version=16b
 android_api_version=19
-go_version=1.16.3
 
 # Create a .dockcross bootstrap file for the dockcross container, which is its init script
 # Note that commands going into dockcross need to be quoted based on which shell you want the expansion done by. If the
@@ -93,8 +92,6 @@ function build_android {
     if [ ! -e android-ndk-r${android_ndk_version} ]; then
         cp -r /tmp/openssl-${os}-${arch}/android-ndk-r${android_ndk_version} android-ndk-r${android_ndk_version}
     fi
-    curl -sSL -o go.tar.gz  https://golang.org/dl/go${go_version}.linux-amd64.tar.gz
-    tar -C /work -xzf go${go_version}.linux-amd64.tar.gz
     # configure the android SDK via .dockcross config
     # No interpolation, expand in the dockcross shell
     (cat <<- BOOT
@@ -105,7 +102,6 @@ export ANDROID_NDK_HOME=/work/android-ndk-r${android_ndk_version}
 export PACKAGE_NAME=libcrypto-${libcrypto_version}-${os}-${arch}.tar.gz
 export LIBCRYPTO_PLATFORM=${openssl_target}
 export COMPILE_FLAGS=${compile_flags}
-export PATH=/work/go/bin:$PATH
 BOOT
     )>> .dockcross
     # No interpolation, eval in dockcross shell

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -301,8 +301,7 @@ TARGETS = {
     'android': {
         'cmake_args': [
             "-DTARGET_ARCH=ANDROID",
-            "-DANDROID_NATIVE_API_LEVEL=19",
-            "-DDISABLE_GO=ON"
+            "-DANDROID_NATIVE_API_LEVEL=19"
         ],
         'run_tests': False,
 

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -301,7 +301,8 @@ TARGETS = {
     'android': {
         'cmake_args': [
             "-DTARGET_ARCH=ANDROID",
-            "-DANDROID_NATIVE_API_LEVEL=19"
+            "-DANDROID_NATIVE_API_LEVEL=19",
+            "-DDISABLE_GO=ON"
         ],
         'run_tests': False,
 

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -309,11 +309,13 @@ TARGETS = {
             'armv7': {
                 'cmake_args': [
                     "-DANDROID_ABI=armeabi-v7a",
+                    "-DCMAKE_SYSTEM_PROCESSOR=armv7-a"
                 ]
             },
             'arm64v8a': {
                 'cmake_args': [
                     "-DANDROID_ABI=arm64-v8a",
+                    "-DCMAKE_SYSTEM_PROCESSOR=aarch64"
                 ],
             },
         },


### PR DESCRIPTION
*Issue:*
Android build for AWS-LC requires Go by default. But there is a flag to disable Go.

*Description of changes:*
Added `-DDISABLE_GO=ON` in cmake_args for Android build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
