### PR TITLE
Ensuring CI builds of CRT libraries are appropriately strict

### DIFF
--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -88,6 +88,7 @@ def _build_project(env, project, cmake_extra, build_tests=False):
         "-H{}".format(project_source_dir),
         # "-Werror=dev",
         # "-Werror=deprecated",
+        "-DAWS_WARNINGS_ARE_ERRORS=ON",
         "-DCMAKE_INSTALL_PREFIX=" + project_install_dir,
         "-DCMAKE_PREFIX_PATH=" + project_install_dir,
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",


### PR DESCRIPTION
*Description of changes:*
* Utilizing flag created here: https://github.com/awslabs/aws-c-common/pull/798 and rename updated here https://github.com/awslabs/aws-c-common/pull/799

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
