### PR TITLE
Force the PHP version to be supplied during docker builds

### DIFF
--- a/.github/docker-images/phpbrew-linux-x64/Dockerfile
+++ b/.github/docker-images/phpbrew-linux-x64/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:latest
 
-ARG PHP_VERSION=5.5
+ARG PHP_VERSION
 
 ###############################################################################
 # Install prereqs

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -109,7 +109,7 @@ jobs:
         image_name: awslabs/aws-crt-builder/aws-crt-php${{ matrix.version }}-linux-x64
         image_tag: ${{ steps.tag.outputs.release_tag }}
         context: .github/docker-images/phpbrew-linux-x64
-        build_extra_args: --compress=true --build-arg PHP_VERSION=${{matrix.version}}
+        build_extra_args: --compress=true --build-arg=PHP_VERSION=${{matrix.version}}
 
     - name: Export PHP ${{ matrix.version }} image to S3/channels/${{ steps.tag.outputs.release_tag }}
       run: |


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
