### PR TITLE
Pass CI credentials to builder

### DIFF
--- a/.github/workflows/linux-container-ci.sh
+++ b/.github/workflows/linux-container-ci.sh
@@ -11,4 +11,4 @@ shift
 
 aws ecr get-login-password | docker login 123124136734.dkr.ecr.us-east-1.amazonaws.com -u AWS --password-stdin
 export DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/${IMAGE_NAME}:${BUILDER_VERSION}
-docker run --env GITHUB_REF $DOCKER_IMAGE --version=${BUILDER_VERSION} $@
+docker run --env GITHUB_REF --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_DEFAULT_REGION $DOCKER_IMAGE --version=${BUILDER_VERSION} $@


### PR DESCRIPTION
Matches the pattern used by aws-c-s3 and all the CRTs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
