### PR TITLE
Add sudo to new docker images

### DIFF
--- a/.github/docker-images/opensuse-leap/Dockerfile
+++ b/.github/docker-images/opensuse-leap/Dockerfile
@@ -3,7 +3,7 @@ FROM opensuse/leap:15.2
 SHELL ["/bin/bash", "-c"]
 
 RUN zypper refresh && zypper --non-interactive patch
-RUN zypper install -y git gcc gcc-c++ cmake curl python3 python3-pip wget
+RUN zypper install -y git gcc gcc-c++ cmake curl python3 python3-pip wget sudo
 
 ###############################################################################
 # Install entrypoint

--- a/.github/docker-images/rhel8-x64/Dockerfile
+++ b/.github/docker-images/rhel8-x64/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y gcc gcc-c++ cmake wget python3 python3-pip git make
+RUN dnf install -y gcc gcc-c++ cmake wget python3 python3-pip git make sudo
 
 ###############################################################################
 # Install entrypoint


### PR DESCRIPTION
**Issue:**
2 of the newer docker images didn't have the `sudo` command, which causes errors if a `builder.json` file tried to install something.

**Description of changes:**
Add sudo to docker images that didn't already have it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
