### PR TITLE
fix: add java 11 to ubuntu swift image

### DIFF
--- a/.github/docker-images/swift-5-ubuntu-x64/Dockerfile
+++ b/.github/docker-images/swift-5-ubuntu-x64/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qq \
     && apt-get -y install \
     sudo \
     curl \
+    wget \
     # Python
     python3 \
     python3-pip \
@@ -18,6 +19,13 @@ RUN apt-get update -qq \
     apt-transport-https \
     ca-certificates \
     && apt-get clean
+
+###############################################################################
+# Add the corretto repo and public key and install corretto
+###############################################################################
+RUN wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add - 
+RUN sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+RUN apt-get -y install java-11-amazon-corretto-jdk
 
 ###############################################################################
 # Python/AWS CLI


### PR DESCRIPTION
*Description of changes:* Need java 11 on swift ubuntu image in order to run gradle build in sdk ci


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
