### PR TITLE
Diagnose why aws-crt-python downstream check is failing

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -256,6 +256,7 @@ jobs:
         path: .
 
     - name: Build ${{ matrix.project }}
+      # why you break why why
       run: python3 builder.pyz build --project ${{ matrix.project }} --compiler=clang
 
   # This mostly tests that libcrypto and s2n resolve correctly on manylinux vs ubuntu


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
