### PR TITLE
fix: add new docker images

### DIFF
--- a/.github/docker-images/swift-5-al2-x64/Dockerfile
+++ b/.github/docker-images/swift-5-al2-x64/Dockerfile
@@ -1,5 +1,5 @@
 #https://github.com/apple/swift-docker/blob/d3a19f47844d7d4d0dab0b59153da1f1596543b6/5.5/amazonlinux/2/Dockerfile
-FROM swift:5.5.2-amazonlinux2
+FROM swift:5.5.3-amazonlinux2
 
 ###############################################################################
 # Install prereqs

--- a/.github/docker-images/swift-5-centos-x64/Dockerfile
+++ b/.github/docker-images/swift-5-centos-x64/Dockerfile
@@ -1,5 +1,5 @@
 #https://github.com/apple/swift-docker/blob/d3a19f47844d7d4d0dab0b59153da1f1596543b6/5.5/centos/7/Dockerfile
-FROM swift:5.5.2-centos7
+FROM swift:5.5.3-centos7
 
 ###############################################################################
 # Install prereqs

--- a/.github/docker-images/swift-5-ubuntu-x64/Dockerfile
+++ b/.github/docker-images/swift-5-ubuntu-x64/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/apple/swift-docker/blob/d3a19f47844d7d4d0dab0b59153da1f1596543b6/5.5/ubuntu/16.04/Dockerfile
-FROM swift:5.5.2-focal
+FROM swift:5.5.3-focal
 
 ###############################################################################
 # Install prereqs


### PR DESCRIPTION
*Description of changes:* Directly following the release of Swift 5.5.3, this updates the docker images to use the new version which fixes a compiler bug when using Swift on Linux with async support.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
