### PR TITLE
Fix project dependency bug.

### DIFF
--- a/builder/actions/git.py
+++ b/builder/actions/git.py
@@ -63,7 +63,7 @@ class DownloadDependencies(Action):
             sh.pushd(env.deps_dir)
 
             while deps:
-                dep = deps.pop()
+                dep = deps.pop(0)  # pop front
                 dep_proj = Project.find_project(dep.name)
                 if dep_proj.path:
                     continue
@@ -73,8 +73,8 @@ class DownloadDependencies(Action):
 
                 # grab updated project, collect transitive dependencies/consumers
                 dep_proj = Project.find_project(dep.name)
-                deps += dep_proj.get_dependencies(spec)
+                deps = dep_proj.get_dependencies(spec) + deps  # push front
                 if spec and spec.downstream:
-                    deps += dep_proj.get_consumers(spec)
+                    deps += dep_proj.get_consumers(spec)  # push back
 
             sh.popd()

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -635,7 +635,7 @@ class Project(object):
 
     def get_dependencies(self, spec):
         """ Gets immediate dependencies for a given BuildSpec, filters by target """
-        dependencies = _resolve_projects(self, self.config.get('upstream', []))
+        dependencies = _resolve_projects(self, self.get_config(spec).get('upstream', []))
         target = spec.target
         filtered = []
         for p in dependencies:
@@ -662,7 +662,7 @@ class Project(object):
 
     def get_consumers(self, spec):
         """ Gets consumers for a given BuildSpec, filters by target """
-        consumers = _resolve_projects(self, self.config.get('downstream', []))
+        consumers = _resolve_projects(self, self.get_config(spec).get('downstream', []))
         target = spec.target
         filtered = []
         for c in consumers:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -123,6 +123,7 @@ class TestProject(unittest.TestCase):
 
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
+        mock_env.spec = BuildSpec()
         steps = p.pre_build(mock_env)
         self._assert_step_contains_all(steps, ['build dependencies', 'build lib-1'])
 
@@ -148,6 +149,7 @@ class TestProject(unittest.TestCase):
 
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
+        mock_env.spec = BuildSpec()
         steps = p.build_consumers(mock_env)
         self._assert_step_contains_all(steps, ['test lib-1'])
 
@@ -164,6 +166,7 @@ class TestProject(unittest.TestCase):
 
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
+        mock_env.spec = BuildSpec()
         steps = p.build_consumers(mock_env)
         self._assert_step_not_contains(steps, 'test lib-1')
 
@@ -178,6 +181,7 @@ class TestProject(unittest.TestCase):
 
         p = Project(**config)
         mock_env = mock.Mock(name='MockEnv', config=config)
+        mock_env.spec = BuildSpec()
         steps = p.build_consumers(mock_env)
         self._assert_step_contains_all(steps, ['post build lib-1', 'test lib-1'])
 
@@ -192,7 +196,7 @@ class TestProject(unittest.TestCase):
         ]
 
         p = Project(**config)
-        spec = mock.Mock(name='MockBuildSpec', spec=BuildSpec, target='linux')
+        spec = BuildSpec(target='linux')
         deps = p.get_dependencies(spec)
         self.assertEqual('explicit-branch', deps[0].revision)
 
@@ -207,7 +211,7 @@ class TestProject(unittest.TestCase):
         ]
 
         p = Project(**config)
-        spec = mock.Mock(name='MockBuildSpec', spec=BuildSpec, target='macos')
+        spec = BuildSpec(target='macos')
         dependencies = p.get_dependencies(spec)
         self.assertEqual(0, len(dependencies), "dependencies should have filtered upstream with specific target")
 
@@ -221,8 +225,8 @@ class TestProject(unittest.TestCase):
         ]
 
         p = Project(**config)
-        m_spec = mock.Mock(name='MockBuildSpec', spec=BuildSpec, target='macos')
-        dependencies = p.get_dependencies(m_spec)
+        spec = BuildSpec(target='macos')
+        dependencies = p.get_dependencies(spec)
         m_env = mock.Mock(name='MockEnv', config=config)
         steps = dependencies[0].post_build(m_env)
         self._assert_step_contains(steps, "{}/gradlew postBuildTask".format(os.path.join(test_data_dir, "lib-1")))


### PR DESCRIPTION
When processing aws-c-io, Builder wouldn't notice the fact that aws-c-cal was using a pinned version of aws-lc.

There were 2 reasons for this:
1) Builder was only doing fancy resolution of platform-specific dependencies for the main project. aws-c-cal only depends on aws-lc for nix platforms, but this wasn't being noticed. Now Builder does fancy resolution for all projects.
2) Builder was pulling dependencies in a weird order. Now builder tries to pull upstream stuff first, and downstream stuff last.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
