### PR TITLE
stop using ubuntu-18.04 Github runner

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019]
+        host: [ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, windows-2019]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:
@@ -172,7 +172,7 @@ jobs:
           - gcc-7
           - gcc-8
     needs: [package]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Source
       uses: actions/checkout@v2
@@ -189,7 +189,7 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ubuntu-18.04 is deprecated, see: https://github.com/actions/runner-images/issues/6002


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
