### PR TITLE
Stop using python 3.6, which is long past end of life.

### DIFF
--- a/.github/docker-images/opensuse-leap/Dockerfile
+++ b/.github/docker-images/opensuse-leap/Dockerfile
@@ -3,7 +3,7 @@ FROM opensuse/leap:15.3
 SHELL ["/bin/bash", "-c"]
 
 RUN zypper refresh
-RUN zypper install -y git gcc gcc-c++ cmake curl python3 python3-pip wget sudo python3-devel tar gzip
+RUN zypper install -y git gcc gcc-c++ cmake curl python39-devel python39-pip wget sudo tar gzip
 
 # normally we let the builder install this, but the builder does a non-standard install that doesn't play nice
 # with opensuse's alternatives framework.  So just install the jdk 11 development package in the base container
@@ -13,8 +13,8 @@ RUN zypper install -y java-11-openjdk-devel
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN python3 -m pip install --upgrade pip setuptools virtualenv \
-    && python3 -m pip install --upgrade awscli \
+RUN python3.9 -m pip install --upgrade pip setuptools virtualenv \
+    && python3.9 -m pip install --upgrade awscli \
     && aws --version
 
 ###############################################################################

--- a/.github/docker-images/rhel8-x64/Dockerfile
+++ b/.github/docker-images/rhel8-x64/Dockerfile
@@ -2,7 +2,17 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y gcc gcc-c++ cmake wget python39 git make sudo python39-devel
+RUN dnf install -y \
+    gcc \
+    gcc-c++ \
+    cmake \
+    wget \
+    git \
+    make \
+    sudo \
+    # RHEL8's default python3 is python3.6, which is EOL.
+    # So install python3.9 (latest version on this distro, circa Oct 2022)
+    python39-devel
 
 ###############################################################################
 # Python/AWS CLI

--- a/.github/docker-images/rhel8-x64/Dockerfile
+++ b/.github/docker-images/rhel8-x64/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y gcc gcc-c++ cmake wget python3 python3-pip git make sudo python3-devel
+RUN dnf install -y gcc gcc-c++ cmake wget python39 git make sudo python39-devel
 
 ###############################################################################
 # Python/AWS CLI

--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update -qq \
     sudo \
     unzip \
     # Python
-    python3 \
-    python3-dev \
-    python3-pip \
+    python3.8 \
+    python3.8-dev \
+    python3.8-pip \
     build-essential \
     # For PPAs
     software-properties-common \
@@ -27,8 +27,8 @@ RUN apt-get update -qq \
 ###############################################################################
 WORKDIR /tmp
 
-RUN python3 -m pip install setuptools \
-    && python3 -m pip install --upgrade pip \
+RUN python3.8 -m pip install setuptools \
+    && python3.8 -m pip install --upgrade pip \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
     && unzip awscliv2.zip \
     && sudo aws/install \

--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -11,10 +11,12 @@ RUN apt-get update -qq \
     curl \
     sudo \
     unzip \
-    # Python
-    python3.8 \
+    # Ubuntu18's default python3 is python3.6, which is EOL.
+    # So install python3.8 (latest version on this distro, circa Oct 2022)
     python3.8-dev \
-    python3.8-pip \
+    # This installs pip for all python versions on the system
+    # (there is no "python3.8-pip")
+    python3-pip \
     build-essential \
     # For PPAs
     software-properties-common \

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -133,6 +133,9 @@ HOSTS = {
         ],
         'pkg_update': 'apt-get -qq update -y',
         'pkg_install': 'apt-get -qq install -y',
+        'variables': {
+            'python': "python3.8",
+        },
     },
     'debian': {
         'os': 'linux',

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -172,6 +172,9 @@ HOSTS = {
         'pkg_tool': PKG_TOOLS.ZYPPER,
         'pkg_update': 'zypper refresh && zypper --non-interactive patch',
         'pkg_install': 'zypper install -y',
+        'variables': {
+            'python': "python3.9",
+        },
     },
     'rhel': {
         'os': 'linux',


### PR DESCRIPTION
**Issue:**

aws-crt-python is removing support for python3.6: https://github.com/awslabs/aws-crt-python/pull/402
but several of our docker images are still using python3.6

**Description of change:**

For distros where python3.6 was the default (ubuntu18, rhel8), switch to using the newest python version available to that distro.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
