### PR TITLE
added ubuntu 20 x64

### DIFF
--- a/.github/docker-images/ubuntu-20-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-20-x64/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+###############################################################################
+# Install prereqs
+###############################################################################
+RUN apt-get update -qq \
+    && apt-get -y install \
+    git \
+    curl \
+    sudo \
+    unzip \
+    python3-dev \
+    python3-pip \
+    build-essential \
+    # For PPAs
+    software-properties-common \
+    apt-transport-https \
+    ca-certificates \
+    && apt-get clean
+
+###############################################################################
+# Python/AWS CLI
+###############################################################################
+WORKDIR /tmp
+
+RUN python3 -m pip install setuptools \
+    && python3 -m pip install --upgrade pip \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && sudo aws/install \
+    && aws --version
+
+###############################################################################
+# Install pre-built CMake
+###############################################################################
+RUN curl -sSL https://d19elf31gohf1l.cloudfront.net/_binaries/cmake/cmake-3.13-manylinux1-x64.tar.gz -o cmake.tar.gz \
+    && tar xvzf cmake.tar.gz -C /usr/local \
+    && cmake --version \
+    && rm -f /tmp/cmake.tar.gz
+
+###############################################################################
+# Install entrypoint
+###############################################################################
+ADD entrypoint.sh /usr/local/bin/builder
+RUN chmod a+x /usr/local/bin/builder
+ENTRYPOINT ["/usr/local/bin/builder"]

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -68,6 +68,7 @@ jobs:
         - al2012-x64
         - al2-x64
         - ubuntu-18-x64
+        - ubuntu-20-x64
         - ubuntu-20-aarch64
         - debian-stretch-arm32v5
         - debian-stretch-arm32v7

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,6 +61,7 @@ jobs:
         - al2012-x64
         - al2-x64
         - ubuntu-18-x64
+        - ubuntu-20-x64
         - ubuntu-20-aarch64
         - debian-stretch-arm32v5
         - debian-stretch-arm32v7


### PR DESCRIPTION
Python 3.6 is no longer supported and was the default for Ubuntu 16.
Added Ubuntu 20 whose default is Python 3.8.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
