### PR TITLE
Bump @vercel/ncc from 0.34.0 to 0.36.0

### DIFF
--- a/.github/actions/check-submodules/package-lock.json
+++ b/.github/actions/check-submodules/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/exec": "^1.1.1"
       },
       "devDependencies": {
-        "@vercel/ncc": "^0.34.0"
+        "@vercel/ncc": "^0.36.0"
       }
     },
     "node_modules/@actions/core": {
@@ -47,9 +47,9 @@
       "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -104,9 +104,9 @@
       "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
     },
     "@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true
     },
     "tunnel": {

--- a/.github/actions/check-submodules/package.json
+++ b/.github/actions/check-submodules/package.json
@@ -14,6 +14,6 @@
     "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.34.0"
+    "@vercel/ncc": "^0.36.0"
   }
 }

--- a/.github/actions/release-tag/package-lock.json
+++ b/.github/actions/release-tag/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.0"
       },
       "devDependencies": {
-        "@vercel/ncc": "^0.34.0"
+        "@vercel/ncc": "^0.36.0"
       }
     },
     "node_modules/@actions/core": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -77,9 +77,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true
     },
     "tunnel": {

--- a/.github/actions/release-tag/package.json
+++ b/.github/actions/release-tag/package.json
@@ -13,6 +13,6 @@
     "@actions/core": "^1.10.0"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.34.0"
+    "@vercel/ncc": "^0.36.0"
   }
 }


### PR DESCRIPTION
This is a copy of a dependebot PR: https://github.com/awslabs/aws-crt-builder/pull/207

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
