### PR TITLE
add --coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage: ```builder.pyz [build|inspect|<action-name>] [spec] [OPTIONS]```
 * ```--build-dir DIR``` - Make a new directory to do all the build work in, instead of using the current directory
 * ```--dump-config``` - Dumps the resultant config after merging all available options. Useful for debugging your project configuration.
 * ```--cmake-extra``` - Extra cmake config arg applied to all projects. e.g ```--cmake-extra=-DBUILD_SHARED_LIBS=ON```. May be specified multiple times.
-* ```--gcc-coverage``` - Use cmake and ctest to generate test coverage report. Only supports gcc as compiler. `gcov` will be used under the hood.
+* ```--coverage``` - Generate the test coverage report and upload it to codecov. Only supported when using cmake and gcc as compiler, error out on other cases.
 
 ### Supported Targets:
 * linux: x86|i686, x64|x86_64, armv6, armv7, arm64|armv8|aarch64|arm64v8

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage: ```builder.pyz [build|inspect|<action-name>] [spec] [OPTIONS]```
 * ```--build-dir DIR``` - Make a new directory to do all the build work in, instead of using the current directory
 * ```--dump-config``` - Dumps the resultant config after merging all available options. Useful for debugging your project configuration.
 * ```--cmake-extra``` - Extra cmake config arg applied to all projects. e.g ```--cmake-extra=-DBUILD_SHARED_LIBS=ON```. May be specified multiple times.
-
+* ```--gcc-coverage``` - Use cmake and ctest to generate test coverage report. Only supports gcc as compiler. `gcov` will be used under the hood.
 
 ### Supported Targets:
 * linux: x86|i686, x64|x86_64, armv6, armv7, arm64|armv8|aarch64|arm64v8

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -158,6 +158,10 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
     if coverage:
         if c_path and "gcc" in c_path:
             # Tell cmake to add coverage related configuration. And make sure GCC is used to compile the project.
+            # CMAKE_C_FLAGS for GCC to enable code coverage information.
+            # COVERAGE_EXTRA_FLAGS="*" is configuration for gcov
+            #   --preserve-paths: to include path information in the report file name
+            #   --source-prefix `pwd`: to exculde the `pwd` from the file name
             cmake_args += [
                 "-DCMAKE_C_FLAGS=-fprofile-arcs -ftest-coverage",
                 "-DCOVERAGE_EXTRA_FLAGS=--preserve-paths --source-prefix `pwd`"

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -159,10 +159,10 @@ def _build_project(env, project, cmake_extra, gcc_coverage=False, build_tests=Fa
     if gcc_coverage:
         if c_path and "gcc" in c_path:
             # Tell cmake to add coverage related configuration. And make sure GCC is used to compile the project.
-            cmake_args + UniqueList([
-                "-DCMAKE_C_FLAGS=\"-fprofile-arcs -ftest-coverage\"",
-                "-DCOVERAGE_EXTRA_FLAGS=\"--preserve-paths --source-prefix `pwd`\""
-            ])
+            cmake_args += [
+                "-DCMAKE_C_FLAGS=-fprofile-arcs -ftest-coverage",
+                "-DCOVERAGE_EXTRA_FLAGS=--preserve-paths --source-prefix `pwd`"
+            ]
         else:
             raise Exception('--gcc-coverage only support GCC as compiler. Current compiler is: {}'.format(c_path))
 

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -101,7 +101,7 @@ def _project_dirs(env, project):
     return source_dir, build_dir, install_dir
 
 
-def _build_project(env, project, cmake_extra, gcc_coverage=False, build_tests=False, args_transformer=None):
+def _build_project(env, project, cmake_extra, build_tests=False, args_transformer=None, gcc_coverage=False):
     sh = env.shell
     config = project.get_config(env.spec)
     toolchain = env.toolchain
@@ -214,7 +214,7 @@ class CMakeBuild(Action):
 
         # BUILD
         build_tests = self.project.needs_tests(env)
-        _build_project(env, self.project, args.cmake_extra, args.gcc_coverage, build_tests, self.args_transformer)
+        _build_project(env, self.project, args.cmake_extra, build_tests, self.args_transformer, args.gcc_coverage)
 
     def __str__(self):
         return 'cmake build {} @ {}'.format(self.project.name, self.project.path)

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -244,9 +244,9 @@ class CTestRun(Action):
         ctest = toolchain.ctest_binary()
         sh.exec(*toolchain.shell_env, ctest,
                 "--output-on-failure", working_dir=project_build_dir, check=True)
-        # Try to generate the coverage report. It's okay to fail.
+        # Try to generate the coverage report. Will be ignored by ctest if no coverage data available.
         sh.exec(*toolchain.shell_env, ctest,
-                "-T coverage", working_dir=project_build_dir)
+                "-T coverage", working_dir=project_build_dir, check=True)
 
     def __str__(self):
         return 'ctest {} @ {}'.format(self.project.name, self.project.path)

--- a/builder/core/shell.py
+++ b/builder/core/shell.py
@@ -150,7 +150,7 @@ class Shell(object):
             result = util.run_command(*command, **kwargs, dryrun=self.dryrun)
         return result
 
-    def get_secret(self, secret_id):
+    def get_secret(self, secret_id, key=None):
         """get string from secretsmanager"""
 
         # NOTE: using AWS CLI instead of boto3 because we know CLI is already
@@ -165,4 +165,8 @@ class Shell(object):
         print('>', subprocess.list2cmdline(cmd))
         result = self.exec(*cmd, check=True, quiet=True)
         secret_value = json.loads(result.output)
-        return secret_value['SecretString']
+        if key is not None:
+            screct_pairs = json.loads(secret_value['SecretString'])
+            return screct_pairs[key]
+        else:
+            return secret_value['SecretString']


### PR DESCRIPTION
- Add `--gcc-coverage`, to generate code coverage repo if available. 
- Only works for using Cmake and GCC as compiler. 
- We could involve more time to make a more generic solution for different compiler, but for real, we only need one working case for the report to work. So, it's not really worth to put time on it for now. We can come back later if we need more case.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
