### PR TITLE
don't repeat output of failed command

### DIFF
--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -39,7 +39,7 @@ def cmake_path(cross_compile=False):
 def cmake_version(cross_compile=False):
     if cross_compile:
         return '3.17.1'
-    output = run_command([cmake_path(), '--version'], quiet=True, stderr=False).output
+    output = run_command([cmake_path(), '--version'], quiet=True).output
     m = re.match(r'cmake(3?) version ([\d\.])', output)
     if m:
         return m.group(2)

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -12,7 +12,7 @@ from builder.core import util
 
 def _compiler_version(cc):
     if current_os() != 'windows':
-        result = util.run_command(cc, '--version', quiet=True, stderr=False)
+        result = util.run_command(cc, '--version', quiet=True)
         lines = result.output.split('\n')
         for text in lines:
             # Apple clang


### PR DESCRIPTION
**Issue:**
The output of a failing command prints twice, making the logs hard to parse.

**Diagnosis:**
It prints once when the command runs, then the output is added to an exception which gets printed out again.

I don't know why the output was ever added to the exception. This was changed 1.5 years ago, but there's no real explanation why in the PR: https://github.com/awslabs/aws-crt-builder/pull/129

This also risks leaking secrets when the command is run with `quiet=True`

**Description of changes:**
- Remove output from Exception
- Use named keyword arguments instead of `**kwargs` so it's easier to figure out what all the options are
- Helpers for stringifying commands args

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
