### PR TITLE
Add OpenBSD as a supported build host

### DIFF
--- a/builder/actions/install.py
+++ b/builder/actions/install.py
@@ -37,7 +37,21 @@ class InstallPackages(Action):
         args = parser.parse_known_args(env.args.args)[0]
 
         sudo = config.get('sudo', current_os() == 'linux')
-        sudo = ['sudo'] if sudo else []
+        if sudo is True:
+            # If (a) the 'sudo' config parameter is set to True, or (b) the
+            # config parameter is not set and the current OS is Linux: use
+            # 'sudo'.
+            sudo = ['sudo']
+        elif sudo is False:
+            # If (a) the 'sudo' config parameter is set to False or (b) the
+            # 'sudo' config parameter is not set and the current OS is not
+            # Linux: do not use a privilege elevation command.
+            sudo = []
+        else:
+            # The 'sudo' config parameter is set and its value is something
+            # other than True: consider the value to be a command (e.g.,
+            # 'doas').
+            sudo = [sudo]
 
         packages = self.packages if self.packages else config.get(
             'packages', [])

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -19,6 +19,7 @@ class PKG_TOOLS(Enum):
     ZYPPER = 'zypper'
     DNF = 'dnf'
     OPKG = 'opkg'
+    OBSD_PKG = 'openbsd_pkg'
 
 
 KEYS = {
@@ -274,6 +275,20 @@ HOSTS = {
         'pkg_tool': PKG_TOOLS.PKG,
         'pkg_update': 'pkg update',
         'pkg_install': 'pkg install -y'
+    },
+    'openbsd': {
+        'os': 'openbsd',
+        'variables': {
+            'python': "python3",
+        },
+        'sudo': 'doas',
+
+        'pkg_tool': PKG_TOOLS.OBSD_PKG,
+        'packages': [
+            'cmake',
+            'python%3.10',
+        ],
+        'pkg_install': 'pkg_add -I'
     }
 }
 
@@ -433,6 +448,14 @@ TARGETS = {
         'variables': {
             'exe': ''
         },
+    },
+    'openbsd': {
+        'cmake_args': [
+            "-DENABLE_SANITIZERS=OFF",
+        ],
+        'variables': {
+            'exe': ''
+        },
     }
 }
 
@@ -448,16 +471,16 @@ for arch in ARCHS.keys():
 ###############################################################################
 COMPILERS = {
     'default': {
-        'hosts': ['macos', 'linux', 'windows', 'freebsd'],
-        'targets': ['macos', 'linux', 'windows', 'freebsd', 'android', 'ios', 'tvos', 'watchos'],
+        'hosts': ['macos', 'linux', 'windows', 'freebsd', 'openbsd'],
+        'targets': ['macos', 'linux', 'windows', 'freebsd', 'openbsd', 'android', 'ios', 'tvos', 'watchos'],
 
         'versions': {
             'default': {}
         }
     },
     'clang': {
-        'hosts': ['linux', 'macos'],
-        'targets': ['linux', 'macos', 'ios', 'tvos', 'watchos'],
+        'hosts': ['linux', 'macos', 'openbsd'],
+        'targets': ['linux', 'macos', 'openbsd', 'ios', 'tvos', 'watchos'],
 
         'imports': ['llvm'],
 
@@ -616,6 +639,7 @@ PLATFORMS = {
     'macos-x64': {},
     'macos-armv8': {},
     'freebsd-x64': {},
+    'openbsd-x64': {},
     'android-armv6': {},
     'android-armv7': {},
     'android-armv8': {},
@@ -659,6 +683,14 @@ for alias in ARCHS['x64'].get('aliases', []):
         alias_freebsd = 'freebsd-{}'.format(alias)
         if alias_freebsd != canonical_freebsd:
             PLATFORMS[alias_freebsd] = PLATFORMS[canonical_freebsd]
+
+# OpenBSD
+for alias in ARCHS['x64'].get('aliases', []):
+    canonical_openbsd = 'openbsd-x64'
+    for alias in ARCHS['x64'].get('aliases', []):
+        alias_openbsd = 'openbsd-{}'.format(alias)
+        if alias_openbsd != canonical_openbsd:
+            PLATFORMS[alias_openbsd] = PLATFORMS[canonical_openbsd]
 
 # Linux works on every arch we support
 for arch in ARCHS.keys():

--- a/builder/core/host.py
+++ b/builder/core/host.py
@@ -19,6 +19,8 @@ def current_os():
         return 'linux'
     elif sys.platform.startswith('freebsd'):
         return 'freebsd'
+    elif sys.platform.startswith('openbsd'):
+        return 'openbsd'
     return 'UNKNOWN'
 
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Adds OpenBSD as a supported host. Tested by running builds of aws-lc, s2n-tls, and aws-c-common on OpenBSD 7.2/amd64. No regressions when building same packages on Ubuntu (22.04).

By adding support for OpenBSD to builder, I will be able to submit PRs to downstream CRT projects to add CI jobs for OpenBSD allowing those projects to identify regressions and breaking changes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
