### PR TITLE
Update MacOS version used in sanity-test

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019]
+        host: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2019]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:


### PR DESCRIPTION
*Description of changes:*

Updates the version of MacOS used in the sanity test from `10.15` to `12`, so we are testing both MacOS 11 and 12 and no longer testing deprecated MacOS containers.

______

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
