### PR TITLE
Tune OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Usage: ```builder.pyz [build|inspect|<action-name>] [spec] [OPTIONS]```
 * macos|darwin: x64|x86_64
 * windows: x86, x64
 * freebsd: x64
+* openbsd: x64
 
 ### Example build
 ```builder.pyz build --project=aws-c-common downstream```

--- a/builder/actions/install.py
+++ b/builder/actions/install.py
@@ -37,21 +37,7 @@ class InstallPackages(Action):
         args = parser.parse_known_args(env.args.args)[0]
 
         sudo = config.get('sudo', current_os() == 'linux')
-        if sudo is True:
-            # If (a) the 'sudo' config parameter is set to True, or (b) the
-            # config parameter is not set and the current OS is Linux: use
-            # 'sudo'.
-            sudo = ['sudo']
-        elif sudo is False:
-            # If (a) the 'sudo' config parameter is set to False or (b) the
-            # 'sudo' config parameter is not set and the current OS is not
-            # Linux: do not use a privilege elevation command.
-            sudo = []
-        else:
-            # The 'sudo' config parameter is set and its value is something
-            # other than True: consider the value to be a command (e.g.,
-            # 'doas').
-            sudo = [sudo]
+        sudo = ['sudo'] if sudo else []
 
         packages = self.packages if self.packages else config.get(
             'packages', [])

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -281,7 +281,7 @@ HOSTS = {
         'variables': {
             'python': "python3",
         },
-        'sudo': 'doas',
+        'sudo': True,
 
         'pkg_tool': PKG_TOOLS.OBSD_PKG,
         'packages': [

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -286,7 +286,6 @@ HOSTS = {
         'pkg_tool': PKG_TOOLS.OBSD_PKG,
         'packages': [
             'cmake',
-            'python%3.10',
         ],
         'pkg_install': 'pkg_add -I'
     }

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -286,6 +286,7 @@ HOSTS = {
         'pkg_tool': PKG_TOOLS.OBSD_PKG,
         'packages': [
             'cmake',
+            'git',
         ],
         'pkg_install': 'pkg_add -I'
     }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Tune OpenBSD support based on learnings from using crt-builder with downstream CRT projects.

- Don't explicitly install python (python has to be installed before running builder so this was redundant at best and just slowed the build at wost)
- Do install git
- Make mention of OpenBSD in the README
- Revert support for doas introduced in 88a4d05 (I've pivoted to a different GitHub action which includes sudo in its OpenBSD VM)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
