### PR TITLE
Unbreak builder on Python < 3.6

### DIFF
--- a/builder/actions/script.py
+++ b/builder/actions/script.py
@@ -56,7 +56,7 @@ class Script(Action):
             elif callable(cmd):
                 children += to_list(cmd(env))
             else:
-                print('Unknown script sub command: {}: {}', cmd_type, cmd)
+                print('Unknown script sub command: {}: {}'.format(cmd_type, cmd))
                 sys.exit(4)
         return children
 

--- a/builder/core/util.py
+++ b/builder/core/util.py
@@ -254,7 +254,7 @@ def run_command(*command, check=False, quiet=False, dryrun=False, retries=0, wor
 
                 if proc.returncode != 0:
                     raise Exception(
-                        f'Command exited with code {proc.returncode}')
+                        'Command exited with code {}'.format(proc.returncode))
 
                 return ExecResult(proc.returncode, proc.pid, output)
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -237,7 +237,12 @@ def upload_test_coverage(env):
     try:
         token = env.shell.get_secret("codecov-token", env.project.name)
     except:
-        print(f"No token found for {env.project.name}, check https://app.codecov.io/github/awslabs/{env.project.name}/settings for token and add it to codecov-token in secret-manager.", file=sys.stderr)
+        print(
+            f"No token found for {name}. Check https://app.codecov.io/github/awslabs/{name}/settings"
+            " for token and add it to codecov-token in Secrets Manager."
+                .format(name=env.project.name),
+            file=sys.stderr
+        )
         exit()
     # only works for linux for now
     env.shell.exec('curl', '-Os', 'https://uploader.codecov.io/latest/linux/codecov', check=True)

--- a/builder/main.py
+++ b/builder/main.py
@@ -238,7 +238,7 @@ def upload_test_coverage(env):
         token = env.shell.get_secret("codecov-token", env.project.name)
     except:
         print(
-            f"No token found for {name}. Check https://app.codecov.io/github/awslabs/{name}/settings"
+            "No token found for {name}. Check https://app.codecov.io/github/awslabs/{name}/settings"
             " for token and add it to codecov-token in Secrets Manager."
             .format(name=env.project.name),
             file=sys.stderr

--- a/builder/main.py
+++ b/builder/main.py
@@ -240,7 +240,7 @@ def upload_test_coverage(env):
         print(
             f"No token found for {name}. Check https://app.codecov.io/github/awslabs/{name}/settings"
             " for token and add it to codecov-token in Secrets Manager."
-                .format(name=env.project.name),
+            .format(name=env.project.name),
             file=sys.stderr
         )
         exit()


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Python f-strings became available in Python 3.6. Some of the CI jobs (eg, linux-compat/debian-stretch-arm32* in c-common) use a version of Python < 3.6. This PR allows builder to work in those jobs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
