### PR TITLE
add CMake Flag for gcc 4.8 to disable AVX512-specific optimizations

### DIFF
--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -555,7 +555,10 @@ COMPILERS = {
         'yum_compiler_packages': ['gcc', 'gcc-c++'],
 
         'versions': {
-            '4.8': {},
+            '4.8': {
+                'cmake_args': [
+                    "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX",
+                ], },
             '5': {},
             '6': {},
             '7': {},

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -566,9 +566,7 @@ COMPILERS = {
             '4.8': {
                 # ASan has been broken on 4.8 GCC version distributed on Ubuntu
                 # and will unlikely to get fixed upstream. so turn it off.
-                # Disable AVX512 on GCC 4.8 for aws-lc
-                '+cmake_args': ['-DENABLE_SANITIZERS=OFF',
-                                "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX"],
+                '+cmake_args': ['-DENABLE_SANITIZERS=OFF'],
             },
             '5': {},
             '6': {},

--- a/builder/imports/awslc.py
+++ b/builder/imports/awslc.py
@@ -38,6 +38,13 @@ class AWSLCImport(Import):
             self.path = os.path.join(env.deps_dir, 'aws-lc')
             DownloadSource(project=Project.find_project(self.name), path=env.deps_dir).run(env)
 
+    def cmake_args(self, env):
+        if env.spec.compiler == 'gcc' and env.spec.compiler_version < '5':
+            # Disable AVX512 on old GCC for aws-lc
+            return super().cmake_args(env) + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX']
+
+        return super().cmake_args(env)
+
     def build(self, env):
         return Project.build(Project.find_project(self.name, [self.path]), env)
 

--- a/builder/imports/awslc.py
+++ b/builder/imports/awslc.py
@@ -41,7 +41,7 @@ class AWSLCImport(Import):
     def cmake_args(self, env):
         if env.spec.compiler == 'gcc' and env.spec.compiler_version < '5':
             # Disable AVX512 on old GCC for aws-lc
-            return super().cmake_args(env) + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX']
+            return super().cmake_args(env) + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON']
 
         return super().cmake_args(env)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
