### PR TITLE
Turn off header checks on older MSVC compilers.

### DIFF
--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -1,8 +1,7 @@
 name: Create Channel
 
 # need images created at least once per branch, even if there are no docker changes
-# so that downstream projects can use the branch channel. Also anytime this
-# file is updated
+# so that downstream projects can use the branch channel.
 on:
   push:
     branches-ignore:
@@ -10,9 +9,9 @@ on:
     paths:
       - '.github/workflows/create-channel.yml'
       - '.github/actions/**'
-      - '.github/builder/**'
       - '.github/docker-images/**'
       - '.github/workflows/*.sh'
+      - 'builder/**'
   create:
 
 env:

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -9,9 +9,9 @@ on:
       - 'main'
     paths:
       - '.github/workflows/create-channel.yml'
-      - '.github/actions/**/*'
-      - '.github/docker-images/**/*'
-      - '.github/docker-images/entrypoint.sh'
+      - '.github/actions/**'
+      - '.github/builder/**'
+      - '.github/docker-images/**'
       - '.github/workflows/*.sh'
   create:
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-20.04, macos-11, macos-12, windows-2019]
+        host: [ubuntu-20.04, macos-11, macos-12, windows-2022]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -140,14 +140,14 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
     cmake_args = UniqueList([
         "-B{}".format(project_build_dir),
         "-H{}".format(project_source_dir),
-        # "-Werror=dev",
-        # "-Werror=deprecated",
         "-DAWS_WARNINGS_ARE_ERRORS=ON",
+        "-DPERFORM_HEADER_CHECK=ON",
         "-DCMAKE_INSTALL_PREFIX=" + project_install_dir,
         "-DCMAKE_PREFIX_PATH=" + project_install_dir,
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
         "-DCMAKE_BUILD_TYPE=" + build_config,
         "-DBUILD_TESTING=" + ("ON" if build_tests else "OFF"),
+        "--no-warn-unused-cli",
         *compiler_flags,
     ])
     # Merging in cmake_args from all upstream projects inevitably leads to duplicate arguments.

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -617,7 +617,13 @@ COMPILERS = {
                 'cmake_args': [
                     '-Tv142',
                 ],
-            }
+            },
+            # 2022
+            '17': {
+                'cmake_args': [
+                    '-Tv143',
+                ],
+            },
         },
 
         'architectures': {

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -596,12 +596,20 @@ COMPILERS = {
             '14': {
                 'cmake_args': [
                     '-Tv140',
+                    # The windows-2019 github runner is the last one with the v140 toolset,
+                    # but it has an old Windows 10 SDK whose headers cause level 4 compiler warnings
+                    # https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
+                    '-DPERFORM_HEADER_CHECK=OFF',
                 ],
             },
             # 2017
             '15': {
                 'cmake_args': [
                     '-Tv141',
+                    # The windows-2019 github runner is the last one with the v141 toolset,
+                    # but it has an old Windows 10 SDK whose headers cause level 4 compiler warnings
+                    # https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
+                    '-DPERFORM_HEADER_CHECK=OFF',
                 ],
             },
             # 2019

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -597,7 +597,7 @@ COMPILERS = {
                 'cmake_args': [
                     '-Tv140',
                     # The windows-2019 github runner is the last one with the v140 toolset,
-                    # but it has an old Windows 10 SDK whose headers cause level 4 compiler warnings
+                    # but it has an old Windows 10 SDK whose headers causes level 4 compiler warnings.
                     # https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
                     '-DPERFORM_HEADER_CHECK=OFF',
                 ],
@@ -606,10 +606,6 @@ COMPILERS = {
             '15': {
                 'cmake_args': [
                     '-Tv141',
-                    # The windows-2019 github runner is the last one with the v141 toolset,
-                    # but it has an old Windows 10 SDK whose headers cause level 4 compiler warnings
-                    # https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
-                    '-DPERFORM_HEADER_CHECK=OFF',
                 ],
             },
             # 2019

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -119,10 +119,6 @@ HOSTS = {
         'variables': {
             'python': "python3",
         },
-
-        'cmake_args': [
-            "-DPERFORM_HEADER_CHECK=ON",
-        ],
         'sudo': True
     },
     'ubuntu': {
@@ -195,7 +191,6 @@ HOSTS = {
         'os': 'linux',
         'cmake_args': [
             "-DENABLE_SANITIZERS=OFF",
-            "-DPERFORM_HEADER_CHECK=OFF",
         ],
 
         'pkg_tool': PKG_TOOLS.YUM,
@@ -210,7 +205,6 @@ HOSTS = {
         'os': 'linux',
         'cmake_args': [
             "-DENABLE_SANITIZERS=OFF",
-            "-DPERFORM_HEADER_CHECK=OFF",
         ],
 
         'pkg_tool': PKG_TOOLS.YUM,
@@ -251,10 +245,6 @@ HOSTS = {
 
         'pkg_tool': PKG_TOOLS.CHOCO,
         'pkg_install': 'choco install --no-progress',
-
-        'cmake_args': [
-            "-DPERFORM_HEADER_CHECK=ON",
-        ],
     },
     'macos': {
         'os': 'macos',


### PR DESCRIPTION
*Description of changes:*
- Turn on header checks by default
- Update channel if builder/** is updated
- Add MSVC 17 toolset
- Use latest github runner for Sanity test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
