### PR TITLE
Fix OpenWrt image

### DIFF
--- a/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
+++ b/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir -p /var/lock
 RUN mkdir -p /usr/local/bin
 
 RUN opkg update
+RUN opkg update
 
 # packages in openwrt
 RUN opkg install git-http ca-bundle curl python3 python3-pip gcc make bash sudo

--- a/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
+++ b/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
@@ -1,10 +1,9 @@
-FROM openwrtorg/rootfs
+FROM openwrt/rootfs
 
 # for some reason this directory isn't created by this point and we need it
 RUN mkdir -p /var/lock
 RUN mkdir -p /usr/local/bin
 
-RUN opkg update
 RUN opkg update
 
 # packages in openwrt

--- a/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
+++ b/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwrt/rootfs
+FROM openwrtorg/rootfs
 
 # for some reason this directory isn't created by this point and we need it
 RUN mkdir -p /var/lock

--- a/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
+++ b/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwrtorg/rootfs
+FROM openwrt/rootfs
 
 # for some reason this directory isn't created by this point and we need it
 RUN mkdir -p /var/lock


### PR DESCRIPTION
*Description of changes:*
- Release of builder failed because https://hub.docker.com/r/openwrtorg/rootfs is returning a 404. [Openwrt](https://github.com/openwrt/docker) has switched their docker.io account from openwrtorg to openwrt. Replace the image with https://hub.docker.com/r/openwrt/rootfs. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
