### PR TITLE
Fix same-named branch behavior in Codebuild

### DIFF
--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -153,10 +153,14 @@ class Env(object):
         try:
             branch_output = subprocess.check_output(
                 ["git", "branch", "-a", "--contains", "HEAD"]).decode("utf-8")
+            branches_unfiltered = [branch.strip() for branch in branch_output.splitlines()]
+            print("Found branches:", branches_unfiltered)
+
             branches = []
             star_branch = None
-            for line in branch_output.splitlines():
+            for line in branches_unfiltered:
                 branch = line.lstrip('*').strip()
+
                 # eliminate candidates like "(no branch)" and "(HEAD detached at 1dd6804)"
                 if branch.startswith('('):
                     continue
@@ -165,8 +169,6 @@ class Env(object):
                     star_branch = branch
 
                 branches.append(branch)
-
-            print("Found branches:", branches)
 
             # if git branch says we're on a branch, that's it
             if star_branch:
@@ -182,7 +184,7 @@ class Env(object):
                 print('Working in branch: {}'.format(branch))
                 return branch
         except:
-            print("Current directory () is not a git repository".format(os.getcwd()))
+            print("Current directory ({}) is not a git repository".format(os.getcwd()))
 
         # git symbolic-ref --short HEAD
         return 'main'


### PR DESCRIPTION
**Issue:**
Builder's "check out branches with same-name" behavior wasn't working right on Codebuild. In that environment, git reported its current branches as:
```
* (HEAD detached at 1dd6804)
  stream2
  remotes/origin/stream2
```

I expected it to checkout aws-c-common's `stream2` branch, but instead it tried to checkout the `(HEAD detached at 1dd6804)` branch 😐

**Description of changes:**
we already had code to ignore entries like `(no branch)`, now we have code to ignore all entries starting with `(`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
