### PR TITLE
Add docker image for qemu-user-static

### DIFF
--- a/.github/docker-images/multiarch-qemu-user-static/Dockerfile
+++ b/.github/docker-images/multiarch-qemu-user-static/Dockerfile
@@ -1,0 +1,1 @@
+FROM multiarch/qemu-user-static


### PR DESCRIPTION
*Description of changes:*
- Docker has a pull limit for users, and I encountered issues during testing due to this limit. Add the image to ECR so that we can pull from ECR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
