### PR TITLE
Skip Raspberry Image

### DIFF
--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -128,30 +128,30 @@ jobs:
   # This job is only for a temporary fix. The cheated image would not get updated.
   cheated-images:
     name: ${{ matrix.variant }}
-      runs-on: ubuntu-latest
-      strategy:
-        fail-fast: false
-        matrix:
-          variant:
-          - raspbian-bullseye
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+        - raspbian-bullseye
 
-      steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v4
 
-      - name: Get release tag
-        uses: ./.github/actions/release-tag
-        id: tag
+    - name: Get release tag
+      uses: ./.github/actions/release-tag
+      id: tag
 
-      - name: Login to docker repo
-        run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+    - name: Login to docker repo
+      run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
 
-      - name: Pull latest image and push
-        run: |
-          if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
-            exit 1
-          fi
-          export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
-          docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
-          docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
-          docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+    - name: Pull latest image and push
+      run: |
+        if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
+          exit 1
+        fi
+        export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
+        docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
+        docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+        docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -78,7 +78,6 @@ jobs:
         - rhel8-x64
         - opensuse-leap
         - fedora-34-x64
-        - raspbian-bullseye
         - alpine-3.16-x64
         - alpine-3.16-x86
         - alpine-3.16-arm64
@@ -124,3 +123,35 @@ jobs:
       run: |
         export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
         docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+
+  # The job will directly pull the image from the latest, and push to the new tag.
+  # This job is only for a temporary fix. The cheated image would not get updated.
+  cheated-images:
+    name: ${{ matrix.variant }}
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          variant:
+          - raspbian-bullseye
+
+      steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Get release tag
+        uses: ./.github/actions/release-tag
+        id: tag
+
+      - name: Login to docker repo
+        run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+
+      - name: Pull latest image and push
+        run: |
+          if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
+            exit 1
+          fi
+          export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
+          docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
+          docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+          docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -126,7 +126,7 @@ jobs:
 
   # The job will directly pull the image from the latest, and push to the new tag.
   # This job is only for a temporary fix. The cheated image would not get updated.
-  cheated-images:
+  passthrough-images:
     name: ${{ matrix.variant }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -133,33 +133,33 @@ jobs:
   # This job is only for a temporary fix. The image would not get updated.
   cheat-images:
     name: ${{ matrix.variant }}
-      runs-on: ubuntu-latest
-      strategy:
-        fail-fast: false
-        matrix:
-          variant:
-          - raspbian-bullseye
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+        - raspbian-bullseye
 
-      steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v4
 
-      - name: Get release tag
-        uses: ./.github/actions/release-tag
-        id: tag
+    - name: Get release tag
+      uses: ./.github/actions/release-tag
+      id: tag
 
-      - name: Login to docker repo
-        run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+    - name: Login to docker repo
+      run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
 
-      - name: Pull latest image and push
-        run: |
-          if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
-            exit 1
-          fi
-          export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
-          docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
-          docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
-          docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+    - name: Pull latest image and push
+      run: |
+        if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
+          exit 1
+        fi
+        export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
+        docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
+        docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+        docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
 
   upload-ci-script:
     name: Upload container ci script

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -131,7 +131,7 @@ jobs:
 
   # The job will directly pull the image from the latest, and push to the new tag.
   # This job is only for a temporary fix. The image would not get updated.
-  cheat-images:
+  passthrough-images:
     name: ${{ matrix.variant }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -72,7 +72,6 @@ jobs:
         - rhel8-x64
         - opensuse-leap
         - fedora-34-x64
-        - raspbian-bullseye
         - alpine-3.16-x64
         - alpine-3.16-x86
         - alpine-3.16-arm64
@@ -129,6 +128,38 @@ jobs:
         | gzip \
         | aws s3 cp - s3://${{env.AWS_S3_BUCKET}}/releases/$IMAGE_TAG/aws-crt-${{ matrix.variant }}.tar.gz
         aws s3 cp s3://${{env.AWS_S3_BUCKET}}/releases/$IMAGE_TAG/aws-crt-${{ matrix.variant }}.tar.gz s3://${{env.AWS_S3_BUCKET}}/LATEST/aws-crt-${{ matrix.variant }}.tar.gz
+
+  # The job will directly pull the image from the latest, and push to the new tag.
+  # This job is only for a temporary fix. The image would not get updated.
+  cheat-images:
+    name: ${{ matrix.variant }}
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          variant:
+          - raspbian-bullseye
+
+      steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Get release tag
+        uses: ./.github/actions/release-tag
+        id: tag
+
+      - name: Login to docker repo
+        run: aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+
+      - name: Pull latest image and push
+        run: |
+          if ! aws --region us-east-1 ecr describe-repositories --repository-names aws-crt-${{ matrix.variant }} > /dev/null 2>&1; then \
+            exit 1
+          fi
+          export IMAGE_TAG=${{ steps.tag.outputs.release_tag }}
+          docker pull ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest
+          docker tag ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:latest ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
+          docker push ${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.variant }}:$IMAGE_TAG
 
   upload-ci-script:
     name: Upload container ci script


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As the raspberry image is not available right now. Always pull the latest image and push to ECR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
