### PR TITLE
Resolve regex literals warning

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-20.04, macos-11, macos-12, windows-2022]
+        host: [ubuntu-22.04, macos-11, macos-12, windows-2022]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/builder/actions/setup_cross_ci_helpers.py
+++ b/builder/actions/setup_cross_ci_helpers.py
@@ -215,7 +215,7 @@ def _get_token_slots(env):
 
 def _get_softhsm2_version(env):
     output = _exec_softhsm2_util(env, '--version').output
-    match = re.match('([0-9+])\.([0-9]+).([0-9]+)', output)
+    match = re.match(r'([0-9+])\.([0-9]+).([0-9]+)', output)
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 ################################################################################

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -17,19 +17,19 @@ def _compiler_version(cc):
 
         for text in lines:
             # Apple clang
-            m = re.match('Apple (LLVM|clang) version (\d+)', text)
+            m = re.match(r'Apple (LLVM|clang) version (\d+)', text)
             if m:
                 return 'appleclang', m.group(2)
             # LLVM clang
-            m = re.match('.*(LLVM|clang) version (\d+)', text)
+            m = re.match(r'.*(LLVM|clang) version (\d+)', text)
             if m:
                 return 'clang', m.group(2)
             # GCC 4.x
-            m = re.match('gcc .+ (4\.\d+)', text)
+            m = re.match(r'gcc .+ (4\.\d+)', text)
             if m:
                 return 'gcc', m.group(1)
             # GCC 5+
-            m = re.match('gcc .+ (\d+)\.', text)
+            m = re.match(r'gcc .+ (\d+)\.', text)
             if m:
                 return 'gcc', m.group(1)
     return None, None

--- a/builder/imports/llvm.py
+++ b/builder/imports/llvm.py
@@ -130,7 +130,7 @@ class LLVM(Import):
         sudo = ['sudo'] if sudo else []
 
         # Strip minor version info
-        version = env.toolchain.compiler_version.replace('\..+', '')
+        version = env.toolchain.compiler_version.replace(r'\..+', '')
 
         script = tempfile.NamedTemporaryFile(delete=False)
         script_path = script.name

--- a/builder/imports/nodejs.py
+++ b/builder/imports/nodejs.py
@@ -14,7 +14,7 @@ import os
 import re
 
 
-NVM = """\
+NVM = r"""\
 #!/usr/bin/env bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -126,7 +126,7 @@ class NodeJS(Import):
         # Normaliz version format, please note 12.16.3 is the last version has x86 support
         def normalize_version(v):
             append_times = 0
-            while re.match('^([0-9]+\.){2}[0-9]+$', v) == None:
+            while re.match(r'^([0-9]+\.){2}[0-9]+$', v) == None:
                 # Only try append sub version twice
                 if append_times < 2:
                     v += ".0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Python 3.12 added syntax warning (ex. SyntaxWarning: invalid escape sequence '\d') that triggers on all of our regex's. More info here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
