### PR TITLE
Add unencoded custom auth signature secret 

### DIFF
--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -293,6 +293,8 @@ class SetupCrossCICrtEnvironment(Action):
                             "ci/mqtt5/us/authorizer/signed/tokenkeyname")
         self._setenv_secret(env, "AWS_TEST_MQTT311_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE",
                             "ci/mqtt5/us/authorizer/signed/signature")
+        self._setenv_secret(env, "AWS_TEST_MQTT311_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE_UNENCODED",
+                            "ci/mqtt5/us/authorizer/signed/signature/unencoded")
 
         # JAVA KEYSTORE (Java uses PKCS#8 keys internally, which currently only Linux supports ATM)
         if (self.is_linux == True):

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -205,6 +205,8 @@ class SetupCrossCICrtEnvironment(Action):
                             "ci/mqtt5/us/authorizer/signed/tokenkeyname")
         self._setenv_secret(env, "AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE",
                             "ci/mqtt5/us/authorizer/signed/signature")
+        self._setenv_secret(env, "AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE_UNENCODED",
+                            "ci/mqtt5/us/authorizer/signed/signature/unencoded")
 
         # JAVA KEYSTORE (Java uses PKCS#8 keys internally, which currently only Linux supports ATM)
         if (self.is_linux == True):


### PR DESCRIPTION
Used to verify new flexible custom auth signature intake (handle unencoded values properly).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
