### PR TITLE
Add ability to dump test env vars to file

### DIFF
--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -424,7 +424,7 @@ class SetupCrossCICrtEnvironment(Action):
 
     def run(self, env):
         # A special environment variable indicating that we want to dump test environment variables to a specified file.
-        env_dump_file = env.shell.getenv("SETUP_CROSSS_CRT_TEST_ENVIRONMENT_DUMP_FILE")
+        env_dump_file = env.shell.getenv("AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE")
 
         # Bail if not running tests
         if not env.project.needs_tests(env) and not env_dump_file:

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -423,8 +423,11 @@ class SetupCrossCICrtEnvironment(Action):
         pass
 
     def run(self, env):
+        # A special environment variable indicating that we want to dump test environment variables to a specified file.
+        env_dump_file = env.shell.getenv("SETUP_CROSSS_CRT_TEST_ENVIRONMENT_DUMP_FILE")
+
         # Bail if not running tests
-        if not env.project.needs_tests(env):
+        if not env.project.needs_tests(env) and not env_dump_file:
             print('Tests not needed for project. Skipping setting test environment variables')
             return
 
@@ -475,3 +478,10 @@ class SetupCrossCICrtEnvironment(Action):
         print(f"Detected whether on Codebuild: {self.is_codebuild}")
 
         self._common_setup(env)
+
+        # Create a temporary file with all environment variables.
+        # Useful for running tests locally.
+        if env_dump_file:
+            with open(file=env_dump_file, mode='w+') as file:
+                for env_name, env_value in env.project.config['test_env'].items():
+                    file.write(f"export {env_name}={env_value}\n")


### PR DESCRIPTION
Add possibility to dump testing environment variables to a specified file. The dump file is specified via an environment variable `AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE`.

This is useful when you want to setup your local environment for running tests. Execute the following commands from the repo root to set env vars:

```sh
export AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE=~/work/setup_test_env.inc
builder run SetupCrossCICrtEnvironment -p tests
source ~/work/setup_test_env.inc
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
