### PR TITLE
Fix powershell7.4 issue

### DIFF
--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -16,7 +16,7 @@ environment variables, secrets, files, etc. that is used to build up the testing
 
 # TODO: The variable is used to disable the windows certificate store test to unblock a CI failure.
 # The variable should be set to TRUE after the CI is fixed.
-ENABLE_WINDOWS_CERT_STORE_TEST = False
+ENABLE_WINDOWS_CERT_STORE_TEST = True
 
 
 class SetupCrossCICrtEnvironment(Action):

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -14,8 +14,7 @@ A builder action used by several CRT repositories to setup a set of common, cros
 environment variables, secrets, files, etc. that is used to build up the testing environment.
 """
 
-# TODO: The variable is used to disable the windows certificate store test to unblock a CI failure.
-# The variable should be set to TRUE after the CI is fixed.
+# Enable windows certificate store test
 ENABLE_WINDOWS_CERT_STORE_TEST = True
 
 

--- a/builder/actions/setup_cross_ci_helpers.py
+++ b/builder/actions/setup_cross_ci_helpers.py
@@ -23,6 +23,9 @@ def create_windows_cert_store(env, certificate_env, location_env):
     # Import the PFX into the Windows Certificate Store
     # (Passing '$mypwd' is required even though it is empty and our certificate has no password. It fails CI otherwise)
     import_pfx_arguments = [
+        # Powershell 7.3 introduced an issue where launching powershell from cmd would not set PSModulePath correctly.
+        # As a workaround, we set `PSModulePath` to empty so powershell would automatically reset the PSModulePath to default.
+        # More details: https://github.com/PowerShell/PowerShell/issues/18530
         "$env:PSModulePath = '';",
         "Import-PfxCertificate",
         "-FilePath", pfx_cert_path,

--- a/builder/actions/setup_cross_ci_helpers.py
+++ b/builder/actions/setup_cross_ci_helpers.py
@@ -23,6 +23,7 @@ def create_windows_cert_store(env, certificate_env, location_env):
     # Import the PFX into the Windows Certificate Store
     # (Passing '$mypwd' is required even though it is empty and our certificate has no password. It fails CI otherwise)
     import_pfx_arguments = [
+        "$env:PSModulePath = '';",
         "Import-PfxCertificate",
         "-FilePath", pfx_cert_path,
         "-CertStoreLocation", windows_certificate_folder]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Powershell 7.3 introduced an issue where launching powershell from cmd would not set PSModulePath correctly. As a workaround, we set `PSModulePath` to empty so that powershell would automatically reset the PSModulePath to default.
More details: https://github.com/PowerShell/PowerShell/issues/18530


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
