### PR TITLE
chore(ci): Install necessary packages on FreeBSD

### DIFF
--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -274,6 +274,10 @@ HOSTS = {
         'sudo': True,
 
         'pkg_tool': PKG_TOOLS.PKG,
+        'packages': [
+            'cmake',
+            'git',
+        ],
         'pkg_update': 'pkg update',
         'pkg_install': 'pkg install -y'
     },


### PR DESCRIPTION
*Description of changes:*

The FreeBSD base system does not include git or cmake; builder needs to install them. Like OpenBSD, Python isn't included in base either, however the CI job installs that manually because Python is used to download builder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
