### PR TITLE
Fix openwrt

### DIFF
--- a/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
+++ b/.github/docker-images/openwrt-x64-openjdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwrt/rootfs
+FROM openwrt/rootfs:x86-64-v23.05.3
 
 # for some reason this directory isn't created by this point and we need it
 RUN mkdir -p /var/lock


### PR DESCRIPTION
*Issue #, if available:*

- openwrt docker latest is using the SNAPSHOT version of openwrt, and it failed to install gcc
- eg: https://github.com/awslabs/aws-crt-builder/actions/runs/9373963910/job/25862946745?pr=283 

*Description of changes:*

- Pin to the latest stable release resolved the build issue. https://openwrt.org/start

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
