### PR TITLE
add an extra compiler flag for sse2

### DIFF
--- a/builder/imports/awslc.py
+++ b/builder/imports/awslc.py
@@ -60,5 +60,5 @@ class AWSLCProject(Project):
             result = result + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON']
         if env.spec.arch == 'x86':
             # Add -msse2 for compiler on x86.
-            result = result + ['-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse2"']
+            result = result + ['-DCMAKE_C_FLAGS=-msse2']
         return result

--- a/builder/imports/awslc.py
+++ b/builder/imports/awslc.py
@@ -54,8 +54,11 @@ class AWSLCProject(Project):
             **kwargs)
 
     def cmake_args(self, env):
+        result = super().cmake_args(env)
         if env.spec.compiler == 'gcc' and env.spec.compiler_version.startswith('4.'):
             # Disable AVX512 on old GCC versions for aws-lc as they dont support AVX512 instructions used by aws-lc
-            return super().cmake_args(env) + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON']
-
-        return super().cmake_args(env)
+            result = result + ['-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON']
+        if env.spec.arch == 'x86':
+            # Add -msse2 for compiler on x86.
+            result = result + ['-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse2"']
+        return result


### PR DESCRIPTION
- add compiler flag `-msse2` for aws-lc when building on x86.
- they recently added the https://github.com/aws/aws-lc/commit/6fe8dcbe96e580ea85233fdb98a142e42951b70b, which requires sse2 on x86


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
