### PR TITLE
Bump actions/download-artifact and actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -44,7 +44,7 @@ jobs:
         aws s3 cp build/builder s3://$AWS_S3_BUCKET/channels/$CHANNEL/builder.pyz
 
     - name: Artifact builder
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: builder
         path: build/builder

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,7 +41,7 @@ jobs:
         aws s3 cp build/builder s3://$AWS_S3_BUCKET/releases/${{ steps.tag.outputs.release_tag }}/builder.pyz
 
     - name: Artifact builder
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: builder
         path: build/builder

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -68,7 +68,7 @@ jobs:
         zipinfo -1 build/builder.pyz
 
     - name: Artifact builder
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: builder
         path: build/builder.pyz
@@ -86,7 +86,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .
@@ -148,7 +148,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .
@@ -186,7 +186,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .
@@ -208,7 +208,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .
@@ -258,7 +258,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install builder
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: builder
         path: .


### PR DESCRIPTION
Fixes the following dependabot PRs:
- https://github.com/awslabs/aws-crt-builder/pull/292
- https://github.com/awslabs/aws-crt-builder/pull/270
- https://github.com/awslabs/aws-crt-builder/pull/269


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
