### PR TITLE
Update stale_issue permissions to fix failing workflow

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -9,6 +9,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@v6
       with:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-builder/actions/runs/10676311535

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
