### PR TITLE
XCodebuild Environment Variable Setup

### DIFF
--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -29,9 +29,11 @@ class SetupCrossCICrtEnvironment(Action):
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
         # beside the other functions...
 
-        # XCodebuild will passing env var with "TEST_RUNNER_" prefix into tests. Setup the builder to add
-        # "TEST_RUNNER_" to environment variables when use xcodebuild.
-        # (https://developer.apple.com/documentation/xcode/environment-variable-reference)
+        # We use xcodebuild, Apple's XCode commandline tool, to do iOS/tvOS simulation and tests. 
+        # xcodebuild would pass in environment variables with prefix TEST_RUNNER_ for the tests. For example, if we would like to use environment 
+        # variable FOO in the unit test, we would need set TEST_RUNNER_FOO=BAR. Then xcodebuild will pick up TEST_RUNNER_FOO and stripped 
+        # TEST_RUNNER_ part, using FOO in it's final unit tests.
+        # For more details: https://developer.apple.com/documentation/xcode/environment-variable-reference
         if self.is_xcodebuild:
             env_name = "TEST_RUNNER_"+env_name
         env.shell.setenv(env_name, str(env_data), is_secret=is_secret)

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -19,9 +19,12 @@ ENABLE_WINDOWS_CERT_STORE_TEST = True
 
 
 class SetupCrossCICrtEnvironment(Action):
+    def __init__(self, use_xcodebuild=False):
+        # set to true if using Apple XCodebuild
+        self.use_xcodebuild = use_xcodebuild
 
     def _setenv(self, env, env_name, env_data, is_secret=False):
-        if self.is_xcodebuild:
+        if self.use_xcodebuild:
             env_name = "TEST_RUNNER_"+env_name
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
         # beside the other functions...
@@ -463,8 +466,6 @@ class SetupCrossCICrtEnvironment(Action):
         self.is_arm = False
         # Will be True if on Codebuild
         self.is_codebuild = False
-        # Will be True if is using xcodebuild
-        self.is_xcodebuild = is_xcodebuild
 
         # Any easier way to use in docker without having to always modify the builder action
         if (env.shell.getenv("SETUP_CROSSS_CRT_TEST_ENVIRONMENT_LOCAL", "0") == "1"):

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -22,8 +22,8 @@ class SetupCrossCICrtEnvironment(Action):
     """ Setup Environment Variables for CI Unit Tests """
 
     def __init__(self, use_xcodebuild=False):
-        # set to true if using Apple XCodebuild
-        self.use_xcodebuild = use_xcodebuild
+        # is_xcodebuild set to true if using Apple XCodebuild
+        self.is_xcodebuild = use_xcodebuild
 
     def _setenv(self, env, env_name, env_data, is_secret=False):
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
@@ -32,7 +32,7 @@ class SetupCrossCICrtEnvironment(Action):
         # XCodebuild will passing env var with "TEST_RUNNER_" prefix into tests. Setup the builder to add
         # "TEST_RUNNER_" to environment variables when use xcodebuild.
         # (https://developer.apple.com/documentation/xcode/environment-variable-reference)
-        if self.use_xcodebuild:
+        if self.is_xcodebuild:
             env_name = "TEST_RUNNER_"+env_name
         env.shell.setenv(env_name, str(env_data), is_secret=is_secret)
         # Set it in the test environment as well, for C++

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -19,6 +19,8 @@ ENABLE_WINDOWS_CERT_STORE_TEST = True
 
 
 class SetupCrossCICrtEnvironment(Action):
+    """ Setup Environment Variables for CI Unit Tests """
+
     def __init__(self, use_xcodebuild=False):
         # set to true if using Apple XCodebuild
         self.use_xcodebuild = use_xcodebuild

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -29,9 +29,9 @@ class SetupCrossCICrtEnvironment(Action):
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
         # beside the other functions...
 
-        # We use xcodebuild, Apple's XCode commandline tool, to do iOS/tvOS simulation and tests. 
-        # xcodebuild would pass in environment variables with prefix TEST_RUNNER_ for the tests. For example, if we would like to use environment 
-        # variable FOO in the unit test, we would need set TEST_RUNNER_FOO=BAR. Then xcodebuild will pick up TEST_RUNNER_FOO and stripped 
+        # We use xcodebuild, Apple's XCode commandline tool, to do iOS/tvOS simulation and tests.
+        # xcodebuild would pass in environment variables with prefix TEST_RUNNER_ for the tests. For example, if we would like to use environment
+        # variable FOO in the unit test, we would need set TEST_RUNNER_FOO=BAR. Then xcodebuild will pick up TEST_RUNNER_FOO and stripped
         # TEST_RUNNER_ part, using FOO in it's final unit tests.
         # For more details: https://developer.apple.com/documentation/xcode/environment-variable-reference
         if self.is_xcodebuild:

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -438,7 +438,7 @@ class SetupCrossCICrtEnvironment(Action):
 
         pass
 
-    def run(self, env, is_xcodebuild=False):
+    def run(self, env):
         # A special environment variable indicating that we want to dump test environment variables to a specified file.
         env_dump_file = env.shell.getenv("AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE")
 

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -21,6 +21,8 @@ ENABLE_WINDOWS_CERT_STORE_TEST = True
 class SetupCrossCICrtEnvironment(Action):
 
     def _setenv(self, env, env_name, env_data, is_secret=False):
+        if self.is_xcodebuild:
+            env_name = "TEST_RUNNER_"+env_name
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
         # beside the other functions...
         env.shell.setenv(env_name, str(env_data), is_secret=is_secret)
@@ -433,7 +435,7 @@ class SetupCrossCICrtEnvironment(Action):
 
         pass
 
-    def run(self, env):
+    def run(self, is_xcodebuild=False, env):
         # A special environment variable indicating that we want to dump test environment variables to a specified file.
         env_dump_file = env.shell.getenv("AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE")
 
@@ -461,6 +463,8 @@ class SetupCrossCICrtEnvironment(Action):
         self.is_arm = False
         # Will be True if on Codebuild
         self.is_codebuild = False
+        # Will be True if is using xcodebuild
+        self.is_xcodebuild = is_xcodebuild
 
         # Any easier way to use in docker without having to always modify the builder action
         if (env.shell.getenv("SETUP_CROSSS_CRT_TEST_ENVIRONMENT_LOCAL", "0") == "1"):

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -435,7 +435,7 @@ class SetupCrossCICrtEnvironment(Action):
 
         pass
 
-    def run(self, is_xcodebuild=False, env):
+    def run(self, env, is_xcodebuild=False):
         # A special environment variable indicating that we want to dump test environment variables to a specified file.
         env_dump_file = env.shell.getenv("AWS_SETUP_CRT_TEST_ENVIRONMENT_DUMP_FILE")
 

--- a/builder/actions/setup_cross_ci_crt_environment.py
+++ b/builder/actions/setup_cross_ci_crt_environment.py
@@ -26,10 +26,14 @@ class SetupCrossCICrtEnvironment(Action):
         self.use_xcodebuild = use_xcodebuild
 
     def _setenv(self, env, env_name, env_data, is_secret=False):
-        if self.use_xcodebuild:
-            env_name = "TEST_RUNNER_"+env_name
         # Kinda silly to have a function for this, but makes the API calls consistent and looks better
         # beside the other functions...
+
+        # XCodebuild will passing env var with "TEST_RUNNER_" prefix into tests. Setup the builder to add
+        # "TEST_RUNNER_" to environment variables when use xcodebuild.
+        # (https://developer.apple.com/documentation/xcode/environment-variable-reference)
+        if self.use_xcodebuild:
+            env_name = "TEST_RUNNER_"+env_name
         env.shell.setenv(env_name, str(env_data), is_secret=is_secret)
         # Set it in the test environment as well, for C++
         env.project.config['test_env'][env_name] = env_data


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
XCodebuild will passing env var "TEST_RUNNER_" into tests. Setup the builder to add "TEST_RUNNER_" to environment variables when use xcodebuild. (https://developer.apple.com/documentation/xcode/environment-variable-reference)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
