### PR TITLE
Fix handling of gcc compiler default case

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -297,7 +297,7 @@ jobs:
         - musllinux-1-1-x64
 
     needs: package
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04 # temporarily downgrade to old ubuntu as 24.04 likes to segfault in the middle of the build 
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -572,7 +572,13 @@ COMPILERS = {
         'yum_compiler_packages': ['gcc', 'gcc-c++'],
 
         'versions': {
-            'default': {},
+            'default': {
+                'c': "gcc",
+                'cxx': "g++",
+                'compiler_packages': ['gcc', 'g++'],
+
+                'apt_compiler_packages': ['gcc', 'g++', 'libstdc++-dev'],
+            },
             '4.8': {
                 # ASan has been broken on 4.8 GCC version distributed on Ubuntu
                 # and will unlikely to get fixed upstream. so turn it off.

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -575,9 +575,8 @@ COMPILERS = {
             'default': {
                 '!c': "gcc",
                 '!cxx': "g++",
-                '!compiler_packages': ['gcc', 'g++'],
-
-                '!apt_compiler_packages': ['gcc', 'g++', 'libstdc++-dev'],
+                '!compiler_packages': [],
+                '!apt_compiler_packages': [],
             },
             '4.8': {
                 # ASan has been broken on 4.8 GCC version distributed on Ubuntu

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -572,6 +572,7 @@ COMPILERS = {
         'yum_compiler_packages': ['gcc', 'gcc-c++'],
 
         'versions': {
+            'default': {},
             '4.8': {
                 # ASan has been broken on 4.8 GCC version distributed on Ubuntu
                 # and will unlikely to get fixed upstream. so turn it off.

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -573,11 +573,11 @@ COMPILERS = {
 
         'versions': {
             'default': {
-                'c': "gcc",
-                'cxx': "g++",
-                'compiler_packages': ['gcc', 'g++'],
+                '!c': "gcc",
+                '!cxx': "g++",
+                '!compiler_packages': ['gcc', 'g++'],
 
-                'apt_compiler_packages': ['gcc', 'g++', 'libstdc++-dev'],
+                '!apt_compiler_packages': ['gcc', 'g++', 'libstdc++-dev'],
             },
             '4.8': {
                 # ASan has been broken on 4.8 GCC version distributed on Ubuntu

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -14,7 +14,6 @@ def _compiler_version(cc):
     if current_os() != 'windows':
         result = util.run_command(cc, '--version', quiet=True)
         lines = result.output.split('\n')
-        print(lines)
 
         for text in lines:
             # Apple clang
@@ -38,6 +37,8 @@ def _compiler_version(cc):
             if m:
                 result = util.run_command(cc, '-dumpfullversion -dumpversion', quiet=True)
                 if result.returncode == 0:
+                    lines2 = result.output.split('\n')
+                    print(lines2)
                     return 'gcc', result.output.split('\n')[0]
     return None, None
 

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -33,7 +33,9 @@ def _compiler_version(cc):
             if m:
                 return 'gcc', m.group(1)
             # other gcc
+            print(text)
             m = re.match(r'^gcc', text)
+            print(m)
             if m:
                 print("got here")
                 result = util.run_command(cc, '-dumpfullversion -dumpversion', quiet=True)

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -33,9 +33,11 @@ def _compiler_version(cc):
             if m:
                 return 'gcc', m.group(1)
             # other gcc
-            m = re.match(r'gcc .+', text)
+            m = re.match(r'^gcc', text)
             if m:
+                print("got here")
                 result = util.run_command(cc, '-dumpfullversion -dumpversion', quiet=True)
+                print(result)
                 if result.returncode == 0:
                     lines2 = result.output.split('\n')
                     print(lines2)

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -33,6 +33,12 @@ def _compiler_version(cc):
             m = re.match(r'gcc .+ (\d+)\.', text)
             if m:
                 return 'gcc', m.group(1)
+            # other gcc
+            m = re.match(r'gcc .+', text)
+            if m:
+                result = util.run_command(cc, '-dumpfullversion -dumpversion', quiet=True)
+                if result.returncode == 0:
+                    return 'gcc', result.output.split('\n')[0]
     return None, None
 
 

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -14,7 +14,6 @@ def _compiler_version(cc):
     if current_os() != 'windows':
         result = util.run_command(cc, '--version', quiet=True)
         lines = result.output.split('\n')
-        print(lines)
 
         for text in lines:
             # Apple clang
@@ -33,18 +32,6 @@ def _compiler_version(cc):
             m = re.match(r'gcc .+ (\d+)\.', text)
             if m:
                 return 'gcc', m.group(1)
-            # other gcc
-            print(text)
-            m = re.match(r'^gcc', text)
-            print(m)
-            if m:
-                print("got here")
-                result = util.run_command(cc, '-dumpfullversion -dumpversion', quiet=True)
-                print(result)
-                if result.returncode == 0:
-                    lines2 = result.output.split('\n')
-                    print(lines2)
-                    return 'gcc', result.output.split('\n')[0]
     return None, None
 
 

--- a/builder/core/toolchain.py
+++ b/builder/core/toolchain.py
@@ -14,6 +14,7 @@ def _compiler_version(cc):
     if current_os() != 'windows':
         result = util.run_command(cc, '--version', quiet=True)
         lines = result.output.split('\n')
+        print(lines)
 
         for text in lines:
             # Apple clang


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently when you try to use default gcc compiler it ends up inserting version (which is 'default') into a bunch of places and the builder fails. override the packages to install to just use os defaults. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
