### PR TITLE
Fix typo is ci jon

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -152,7 +152,7 @@ jobs:
 
   upload-ci-script:
     name: Upload container ci script
-    runs-on: ubuntu-2024
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the typo in which os to use makes the job run forever trying to get the image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
