### PR TITLE
Support: ubuntu-24.04-arm Github runners, Amazon Linux 2023. Fix: aws-crt-cpp sanity test

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -204,11 +204,11 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-9, clang-9]
+        compiler: [gcc-8, clang-9]
         cxx-std: ["11", "14", "17", "20"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
@@ -224,7 +224,7 @@ jobs:
         name: builder
         path: .
 
-    - name: Build aws-crt-cpp with ${{ matrix.compiler }}/${{ matrix.std }}
+    - name: Build aws-crt-cpp with ${{ matrix.compiler }}/cxx${{ matrix.cxx-std }}
       run: |
         python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }} --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }}
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc-9, clang-9]
-        std: [c++11, c++14, c++17, c++2a]
+        cxx-std: ["11", "14", "17", "20"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -226,9 +226,7 @@ jobs:
 
     - name: Build aws-crt-cpp with ${{ matrix.compiler }}/${{ matrix.std }}
       run: |
-        export CXXFLAGS=-std=${{ matrix.std }}
-        export VERBOSE=1
-        python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }}
+        python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }} --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }}
 
   release_notes:
     strategy:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -204,7 +204,7 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +227,7 @@ jobs:
     - name: Build aws-crt-cpp with ${{ matrix.compiler }}/${{ matrix.std }}
       run: |
         export CXXFLAGS=-std=${{ matrix.std }}
+        export CMAKE_C_STANDARD=99
         export VERBOSE=1
         python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }}
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -204,7 +204,7 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +227,7 @@ jobs:
     - name: Build aws-crt-cpp with ${{ matrix.compiler }}/${{ matrix.std }}
       run: |
         export CXXFLAGS=-std=${{ matrix.std }}
+        export VERBOSE=1
         python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }}
 
   release_notes:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -204,11 +204,11 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-8, clang-9]
+        compiler: [gcc-9, clang-9]
         std: [c++11, c++14, c++17, c++2a]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
@@ -227,7 +227,6 @@ jobs:
     - name: Build aws-crt-cpp with ${{ matrix.compiler }}/${{ matrix.std }}
       run: |
         export CXXFLAGS=-std=${{ matrix.std }}
-        export CMAKE_C_STANDARD=99
         export VERBOSE=1
         python3 builder.pyz build -p aws-crt-cpp --compiler=${{ matrix.compiler }}
 

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -147,6 +147,7 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
         "-H{}".format(project_source_dir),
         "-DAWS_WARNINGS_ARE_ERRORS=ON",
         "-DPERFORM_HEADER_CHECK=ON",
+        "-DCMAKE_VERBOSE_MAKEFILE=ON",  # shows all flags passed to compiler & linker
         "-DCMAKE_INSTALL_PREFIX=" + project_install_dir,
         "-DCMAKE_PREFIX_PATH=" + project_install_dir,
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -321,9 +321,6 @@ TARGETS = {
             'armv7': {
                 'run_tests': False
             },
-            'armv8': {
-                'run_tests': False
-            },
             'mips': {
                 'run_tests': False
             },

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -215,6 +215,15 @@ HOSTS = {
             'python': "python3",
         },
     },
+    'al2023': {
+        'os': 'linux',
+        'pkg_tool': PKG_TOOLS.DNF,
+        'pkg_update': 'dnf update -y',
+        'pkg_install': 'dnf install -y',
+        'variables': {
+            'python': "python3",
+        },
+    },
     'manylinux': {
         'os': 'linux',
         'pkg_tool': PKG_TOOLS.YUM,

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -572,7 +572,7 @@ class Project(object):
         return Script(steps, name='post_build {}'.format(self.name))
 
     def test(self, env):
-        run_tests = env.config.get('run_tests', True)
+        run_tests = self.needs_tests(env)
         if not run_tests:
             return
 

--- a/builder/core/project.py
+++ b/builder/core/project.py
@@ -553,7 +553,8 @@ class Project(object):
         for c in consumers:
             build_consumers += _build_project(c, env)
             # build consumer tests
-            build_consumers += to_list(c.test(env))
+            if c.needs_tests(env):
+                build_consumers += to_list(c.test(env))
         if len(build_consumers) == 0:
             return None
         return Script(build_consumers, name='build consumers of {}'.format(self.name))
@@ -572,7 +573,7 @@ class Project(object):
         return Script(steps, name='post_build {}'.format(self.name))
 
     def test(self, env):
-        run_tests = self.needs_tests(env)
+        run_tests = env.config.get('run_tests', True)
         if not run_tests:
             return
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -73,7 +73,8 @@ def run_build(env):
         return env.project.post_build(env)
 
     def test(env):
-        return env.project.test(env)
+        if env.project.needs_tests(env):
+            return env.project.test(env)
 
     def install(env):
         return env.project.install(env)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -16,6 +16,7 @@ _test_proj_config = {
     'name': 'test-proj',
     'search_dirs': [test_data_dir],
     'path': here,
+    'run_tests': True,
 }
 
 
@@ -148,7 +149,8 @@ class TestProject(unittest.TestCase):
         ]
 
         p = Project(**config)
-        mock_env = mock.Mock(name='MockEnv', config=config)
+        m_toolchain = mock.Mock(name='mock toolchain', cross_compile=False)
+        mock_env = mock.Mock(name='MockEnv', config=config, project=p, toolchain=m_toolchain)
         mock_env.spec = BuildSpec()
         steps = p.build_consumers(mock_env)
         self._assert_step_contains_all(steps, ['test lib-1'])
@@ -163,7 +165,8 @@ class TestProject(unittest.TestCase):
         ]
 
         p = Project(**config)
-        mock_env = mock.Mock(name='MockEnv', config=config)
+        m_toolchain = mock.Mock(name='mock toolchain', cross_compile=False)
+        mock_env = mock.Mock(name='MockEnv', config=config, project=p, toolchain=m_toolchain)
         mock_env.spec = BuildSpec()
         steps = p.build_consumers(mock_env)
         self._assert_step_contains_all(steps, ['post build lib-1', 'test lib-1'])


### PR DESCRIPTION
**Issue:**
Github now offers [Linux arm64 runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)! But when I tried using the `ubuntu-24.04-arm` runner in aws-c-common, the unit tests didn't run.

**Description of changes:**
- Remove code that assumed linux/armv8 would **always** be a cross-compile, and therefore shouldn't run tests.
  - There's code in several other places ([1](https://github.com/awslabs/aws-crt-builder/blob/504fa11d0ef9e7df501dc28199ba976ffb3c631d/builder/core/project.py#L611-L628), [2](https://github.com/awslabs/aws-crt-builder/blob/504fa11d0ef9e7df501dc28199ba976ffb3c631d/builder/actions/cmake.py#L236-L243)) that stops test from running when builder is [actually cross-compiling](https://github.com/awslabs/aws-crt-builder/blob/504fa11d0ef9e7df501dc28199ba976ffb3c631d/builder/core/toolchain.py#L93-L95). I could *probably* remove similar overrides that set `run_tests = false` for armv7, armv6, etc in this data.py file ... but I'll keep those as-is for now 

- Add some code to let builder run on Amazon Linux 2023

- Fix aws-crt-cpp sanity-test by setting C++ std version in a different way
    - This took so long to diagnose. TLDR; our tests use custom ASSERT() macros which rely on using the widely supported `##__VA_ARGS__` compiler extension. By default, CMake enables compiler extensions: when you set `CMAKE_CXX_STANDARD=11`, it results in compiler flag `-std=gnu11` (11 with extensions) instead of `-std=c++11` (strict 11). But if you set `export CXXFLAGS=-std=c++11` before building, **new** versions of CMake (but not old versions which is why it still works in some of our CI runs using CMake 3.16.3) will change the default to NOT enable extensions, which breaks our tests. Workaround is to set C++ version via `CMAKE_CXX_STANDARD=11` instead of va `CXXFLAGS=-std=c++11`, which lets CMake continue to use compiler extensions by default. I'll be fixing up our CMake scripts in another PR to force extensions ON when building tests...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
