### PR TITLE
Fix CI for Ubuntu 22

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -189,17 +189,26 @@ jobs:
     needs: [package]
     runs-on: ubuntu-22.04
     steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
     - name: Checkout Source
       uses: actions/checkout@v4
 
-    - name: Install builder
-      uses: actions/download-artifact@v4
+    - name: Get release tag
+      uses: ./.github/actions/release-tag
+      id: tag
       with:
-        name: builder
-        path: .
+        output: tag
 
     - name: Build aws-c-common
-      run: python3 builder.pyz build --project aws-c-common --compiler=${{ matrix.compiler }} run_tests=false
+      run: |
+        aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+        export DOCKER_IMAGE=${{ secrets.AWS_ECR_REPO }}/aws-crt-ubuntu-20-x64:${{ steps.tag.outputs.release_tag }}
+        docker pull $DOCKER_IMAGE
+        docker run --env GITHUB_REF $DOCKER_IMAGE build --project aws-c-common --compiler=${{ matrix.compiler }} run_tests=false
 
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -187,7 +187,7 @@ jobs:
           - gcc-10
           - gcc-11
     needs: [package]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Source
       uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
     needs: [package, sanity_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -262,7 +262,7 @@ jobs:
           - aws-crt-nodejs
 
     needs: package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -169,46 +169,35 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          # Note: 18.04 image is no longer supported by gh and 20.04 image does
-          # not have some of the old compilers we want. disable those for now
-          # until we figure out a way to test them.
-          - clang-6
-          # - clang-7 # this one actually has to be installed by the script
-          # - clang-8
-          - clang-9
-          - clang-10
-          - clang-11
-          # - gcc-4.8
-          # - gcc-5
-          # - gcc-6
-          - gcc-7
-          - gcc-8
+          # Note: The sanity checks don't necessarily have to check all supported compilers. The actual packages should
+          # cover this job.
+          # So, the versions of the compilers listed here are dictated by whatever is supported on GitHub runners.
+          # The current oldest supported image is Ubuntu 22.04. When GitHub obsoletes it, this list should be updated.
+          - clang-13
+          - clang-14
+          - clang-15
+          - clang-16
+          - clang-17
+          - clang-18
           - gcc-9
           - gcc-10
           - gcc-11
+          - gcc-12
+          - gcc-13
     needs: [package]
     runs-on: ubuntu-22.04
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
     - name: Checkout Source
       uses: actions/checkout@v4
 
-    - name: Get release tag
-      uses: ./.github/actions/release-tag
-      id: tag
+    - name: Install builder
+      uses: actions/download-artifact@v4
       with:
-        output: tag
+        name: builder
+        path: .
 
     - name: Build aws-c-common
-      run: |
-        aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
-        export DOCKER_IMAGE=${{ secrets.AWS_ECR_REPO }}/aws-crt-ubuntu-20-x64:${{ steps.tag.outputs.release_tag }}
-        docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build --project aws-c-common --compiler=${{ matrix.compiler }} run_tests=false
+      run: python3 builder.pyz build --project aws-c-common --compiler=${{ matrix.compiler }} run_tests=false
 
   # Make sure linux compilers + stdlibs are installing properly
   std-compat:
@@ -217,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-8, clang-9]
+        compiler: [gcc-9, clang-13]
         cxx-std: ["11", "14", "17", "20"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -172,7 +172,7 @@ jobs:
           # Note: 18.04 image is no longer supported by gh and 20.04 image does
           # not have some of the old compilers we want. disable those for now
           # until we figure out a way to test them.
-          # - clang-6
+          - clang-6
           # - clang-7 # this one actually has to be installed by the script
           # - clang-8
           - clang-9

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -132,7 +132,7 @@ HOSTS = {
         'pkg_update': 'apt-get -qq update -y',
         'pkg_install': 'apt-get -qq install -y',
         'variables': {
-            'python': "python3.8",
+            'python': "python3.10",
         },
     },
     'debian': {


### PR DESCRIPTION
*Issue #, if available:*

The `Ubuntu-20.04` runner is not available anymore.
Some CI jobs fail on `Ubuntu-22.04`:
- clang sanity tests can't find llvm packages
- gcc sanity tests can't find gcc packages
- python3.8: not found

*Description of changes:*

Update versions of the tools used in CI tests.
Checking *some* compilers in this repo's CI should be sufficient. The actual packages perform more thorough job on verifying that all supported compilers work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
