### PR TITLE
Define AWS_CRT_DISABLE_DEPRECATION_WARNINGS

### DIFF
--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -146,6 +146,7 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
         "-B{}".format(project_build_dir),
         "-H{}".format(project_source_dir),
         "-DAWS_WARNINGS_ARE_ERRORS=ON",
+        "-DAWS_CRT_DISABLE_DEPRECATION_WARNINGS",
         "-DPERFORM_HEADER_CHECK=ON",
         "-DCMAKE_VERBOSE_MAKEFILE=ON",  # shows all flags passed to compiler & linker
         "-DCMAKE_INSTALL_PREFIX=" + project_install_dir,


### PR DESCRIPTION
aws-crt-cpp is adding soft-deprecation warnings to its MqttClient and V1 Service Clients. Adding this define will prevent the warnings from being emitted which will in turn allow CI to not fail due to treating warnings as errors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
