### PR TITLE
Fix bunch of CI/CD failure for builder

### DIFF
--- a/.github/docker-images/manylinux2014-x64/Dockerfile
+++ b/.github/docker-images/manylinux2014-x64/Dockerfile
@@ -7,7 +7,7 @@ FROM quay.io/pypa/manylinux2014_x86_64
 ###############################################################################
 RUN yum -y install sudo cmake3 \
     # used in java release pipeline
-    maven \ 
+    maven \
     && yum clean all \
     && ln -s `which cmake3` /usr/bin/cmake \
     && ln -s `which ctest3` /usr/bin/ctest \
@@ -17,8 +17,8 @@ RUN yum -y install sudo cmake3 \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN /opt/python/cp37-cp37m/bin/python -m pip install --upgrade setuptools virtualenv \
-    && /opt/python/cp37-cp37m/bin/python -m pip install --upgrade awscli \
+RUN /opt/python/cp38-cp38/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp38-cp38/bin/python -m pip install --upgrade awscli \
     && ln -s `find /opt -name aws` /usr/local/bin/aws \
     && which aws \
     && aws --version

--- a/.github/docker-images/manylinux2014-x86/Dockerfile
+++ b/.github/docker-images/manylinux2014-x86/Dockerfile
@@ -7,14 +7,14 @@ FROM quay.io/pypa/manylinux2014_i686
 ###############################################################################
 RUN yum -y install sudo \
     # used in java release pipeline
-    maven \ 
+    maven \
     && yum clean all
 
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN /opt/python/cp37-cp37m/bin/python -m pip install --upgrade setuptools virtualenv \
-    && /opt/python/cp37-cp37m/bin/python -m pip install --upgrade awscli \
+RUN /opt/python/cp38-cp38/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp38-cp38/bin/python -m pip install --upgrade awscli \
     && ln -s `find /opt -name aws` /usr/local/bin/aws \
     && which aws \
     && aws --version

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -8,13 +8,10 @@ on:
       - 'main'
     paths:
       - '.github/workflows/create-channel.yml'
-      - '.github/workflows/sanity-test.yml'
       - '.github/actions/**'
-      - '.github/actions/**/*'
       - '.github/docker-images/**'
       - '.github/workflows/*.sh'
       - 'builder/**'
-      - 'tests/**'
   create:
 
 env:
@@ -81,7 +78,7 @@ jobs:
         - name: al2023-x64
         - name: ubuntu-18-x64
         - name: ubuntu-20-x64
-        - name: ubuntu-20-aarch64
+        - name: ubuntu-20-aarch64  
           extra-build-flag: --platform=linux/aarch64
         - name: ubuntu-22-x64
         - name: node-10-linux-x64
@@ -97,7 +94,7 @@ jobs:
         - name: alpine-3.16-armv7
         - name: alpine-3.16-armv6
         - name: openwrt-x64-openjdk8
-
+            
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -8,10 +8,13 @@ on:
       - 'main'
     paths:
       - '.github/workflows/create-channel.yml'
+      - '.github/workflows/sanity-test.yml'
       - '.github/actions/**'
+      - '.github/actions/**/*'
       - '.github/docker-images/**'
       - '.github/workflows/*.sh'
       - 'builder/**'
+      - 'tests/**'
   create:
 
 env:
@@ -78,7 +81,7 @@ jobs:
         - name: al2023-x64
         - name: ubuntu-18-x64
         - name: ubuntu-20-x64
-        - name: ubuntu-20-aarch64  
+        - name: ubuntu-20-aarch64
           extra-build-flag: --platform=linux/aarch64
         - name: ubuntu-22-x64
         - name: node-10-linux-x64
@@ -94,7 +97,7 @@ jobs:
         - name: alpine-3.16-armv7
         - name: alpine-3.16-armv6
         - name: openwrt-x64-openjdk8
-            
+
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -289,8 +289,6 @@ jobs:
         - manylinux1-x64
         - manylinux2014-x86
         - manylinux2014-x64
-        - manylinux2014-aarch64
-        - musllinux-1-1-aarch64
         - musllinux-1-1-x64
 
     needs: package
@@ -310,9 +308,38 @@ jobs:
       with:
         output: tag
 
-    # Only aarch64 needs this, but it doesn't hurt anything
-    - name: Install qemu/docker
-      run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws ecr get-login-password --region us-east-1 | docker login ${{ secrets.AWS_ECR_REPO }} -u AWS --password-stdin
+        export DOCKER_IMAGE=${{ secrets.AWS_ECR_REPO }}/aws-crt-${{ matrix.linux }}:${{ steps.tag.outputs.release_tag }}
+        docker pull $DOCKER_IMAGE
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ steps.tag.outputs.release_tag }} build -p aws-c-cal --spec=downstream run_tests=false
+
+  # This mostly tests that libcrypto and s2n resolve correctly on manylinux vs ubuntu
+  aws-c-cal-arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        linux:
+        - manylinux2014-aarch64
+        - musllinux-1-1-aarch64
+
+    needs: package
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+    - name: Checkout Source
+      uses: actions/checkout@v4
+
+    - name: Get release tag
+      uses: ./.github/actions/release-tag
+      id: tag
+      with:
+        output: tag
 
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -1,12 +1,14 @@
 name: Sanity Tests
 
 on:
-  workflow_run:
-    workflows: ["Create Channel"]
-    types:
-      - completed
+  push:
     branches-ignore:
       - 'main'
+    paths:
+      - '.github/workflows/sanity-test.yml'
+      - 'builder/**'
+      - 'tests/**'
+      - '.github/actions/**/*'
 
 env:
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -39,6 +41,7 @@ jobs:
   package:
     name: Package builder app
     runs-on: ubuntu-24.04
+
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches-ignore:
       - 'main'
-    paths:
-      - '.github/workflows/sanity-test.yml'
-      - 'builder/**'
-      - 'tests/**'
-      - '.github/actions/**/*'
 
 env:
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -355,7 +350,6 @@ jobs:
       matrix:
         linux:
           - swift-5-ubuntu-x64
-          - swift-5-centos-x64
           - swift-5-al2-x64
 
     needs: package

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -1,14 +1,12 @@
 name: Sanity Tests
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Create Channel"]
+    types:
+      - completed
     branches-ignore:
       - 'main'
-    paths:
-      - '.github/workflows/sanity-test.yml'
-      - 'builder/**'
-      - 'tests/**'
-      - '.github/actions/**/*'
 
 env:
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -41,7 +39,6 @@ jobs:
   package:
     name: Package builder app
     runs-on: ubuntu-24.04
-
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-13, macos-14, windows-2022]
+        host: [ubuntu-22.04, macos-13, macos-14, windows-2025]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/pypa/manylinux/issues/1671 Manylinux dropped python3.7 
- this fix the failure of us build and publish the ECR docker image for manylinux https://github.com/awslabs/aws-crt-builder/actions/runs/17447463196/job/49545283153
- This also fixes the `swift-5-centos-x64 Sanity test`. Apparently it was removed from https://github.com/awslabs/aws-crt-builder/pull/328. But since our Sanity test only runs on specific file changes, it didn't run on that PR. That's why we missed this.

*Description of changes:*
- Python3.7 is gone, use 3.8 instead
- This "SHOULD" be caught by CI `Sanity Tests / aws-c-cal (manylinux2014-x64)` and `Create Channel / manylinux2014-x86 (push)`, however, looks like we ignored the CI failures in https://github.com/awslabs/aws-crt-builder/pull/329, as they are not "required". Thus, mark them as required instead.
- Also, those `Sanity Tests` action is not setup 100% right, since it should wait until (Create Channel )[https://github.com/awslabs/aws-crt-builder/actions/runs/17447938239] to finish before they start to run. But, instead of fixing it now, I choose to ~click on the retry bottom... Sorry.~ use GenAI to help out and apparently it failed to kick off the sanity tests correctly. So, I choose to click on the retry bottom for those.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
