### PR TITLE
Bump al2-x64 docker to use python 3.8

### DIFF
--- a/.github/docker-images/al2-x64/Dockerfile
+++ b/.github/docker-images/al2-x64/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update \
     gcc-c++ \
     which \
     && yum clean all \
-    && rm -rf /var/cache/yum
+    && rm -rf /var/cache/yum \
     # insure python3 and pip3 point to python3.8
     && ln -sf /usr/bin/python3.8 /usr/bin/python3 \
     && ln -sf /usr/bin/pip3.8 /usr/bin/pip3


### PR DESCRIPTION
al2-x64 docker when installing Python3 appears to install Python 3.7. We have bumped the min version of Python to 3.8. Python CRT is failing due to 3.8 not being used in CI so we are bumping it here.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
