### PR TITLE
Bump from Python 3.8 to 3.10 on Ubuntu 18 x64

### DIFF
--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -46,10 +46,11 @@ RUN cd /tmp \
     && ln -sf /usr/local/bin/python3.10 /usr/bin/python3 \
     && /usr/local/bin/python3.10 --version
 
-# Add Go PPA and install
-RUN add-apt-repository -y ppa:longsleep/golang-backports \
-    && apt-get update \
-    && apt-get -y install golang-go \
+# Install Go from default Ubuntu repository
+RUN apt-get update \
+    && apt-get -y install \
+    software-properties-common \
+    golang-go \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Bump the Docker file for ubuntu-18-x64 from Python 3.8 to 3.10.

As Python 3.10 is not available for ubuntu-18-x64 (nothing is ever easy) we need to build it ourselves. This is a pain but the alternatives feel worse and more complicated. We need to use ubuntu-18-64 to run compiler tests across a number of repos that are testing as old as clang 6 and gcc 5. Someday we can stop testing things that ancient but until then, this is the way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
