### PR TITLE
Switch cmake_args to ordinary list

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-13, macos-14, windows-2025]
+        host: [ubuntu-22.04, macos-latest, windows-2025]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-latest, windows-2025]
+        host: [ubuntu-22.04, macos-14, macos-latest, windows-2025]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-14, macos-latest, windows-2025]
+        host: [ubuntu-22.04, macos-14, macos-15, windows-2025]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -148,7 +148,7 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
     # For examp[le, ENABLE_SANITIZERS is set to OFF by default but ON by host config, if we want to turn it off again for
     # specific jobs, having a UniqueList would not allow that.
     # TODO: We need to take into account flags which can have key value pairs while trying to make a unique list and update
-    # keys with the latest 'value' based on priority instead of treating it as an element in the list. This would allow not 
+    # keys with the latest 'value' based on priority instead of treating it as an element in the list. This would allow not
     # duplicating flags.
     cmake_args = [
         "-B{}".format(project_build_dir),

--- a/builder/actions/cmake.py
+++ b/builder/actions/cmake.py
@@ -142,7 +142,15 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
             if value:
                 compiler_flags.append(
                     '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), value))
-    cmake_args = UniqueList([
+
+    # Removed UniqueList to make an ordinary list instead. Having multiple arguments in different parts of the command
+    # is acceptable since it helps debug where and how flags are added and override previous definitions based on priority.
+    # For examp[le, ENABLE_SANITIZERS is set to OFF by default but ON by host config, if we want to turn it off again for
+    # specific jobs, having a UniqueList would not allow that.
+    # TODO: We need to take into account flags which can have key value pairs while trying to make a unique list and update
+    # keys with the latest 'value' based on priority instead of treating it as an element in the list. This would allow not 
+    # duplicating flags.
+    cmake_args = [
         "-B{}".format(project_build_dir),
         "-H{}".format(project_source_dir),
         "-DAWS_WARNINGS_ARE_ERRORS=ON",
@@ -155,13 +163,7 @@ def _build_project(env, project, cmake_extra, build_tests=False, args_transforme
         "-DBUILD_TESTING=" + ("ON" if build_tests else "OFF"),
         "--no-warn-unused-cli",
         *compiler_flags,
-    ])
-    # Merging in cmake_args from all upstream projects inevitably leads to duplicate arguments.
-    # Using a UniqueList seems to solve the problem well enough for now.
-    # TODO: this can lead to unpredictable results for cases where same flag is
-    # set on and off multiple times. ex. Flag A is added to args with value On,
-    # Off, On. With UniqueList last On will be removed and cmake will treat flag
-    # as off. Without UniqueList cmake will treat it as on.
+    ]
     cmake_args += project.cmake_args(env)
     cmake_args += cmake_extra
     if coverage:

--- a/builder/actions/setup_cross_ci_helpers.py
+++ b/builder/actions/setup_cross_ci_helpers.py
@@ -61,8 +61,8 @@ def create_windows_cert_store(env, certificate_env, location_env):
 def create_pkcs11_environment(env, pkcs8key, pkcs8cert, ca_file):
     # try to install softhsm
     try:
-        softhsm_install_acion = InstallPackages(['softhsm'])
-        softhsm_install_acion.run(env)
+        softhsm_install_action = InstallPackages(['softhsm'])
+        softhsm_install_action.run(env)
     except:
         print("WARNING: softhsm could not be installed. PKCS#11 tests are disabled")
         return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
cmake_args being unique list some times causes incorrect behavior since args appended later might not be respected due it the arg already being in the 'unique list'. 
CMake itself processes args from left to right takes the latest value appended, this way args with higher priority can be appended to the end allowing CMake to resolve multiple instances of the same args.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
