### PR TITLE
ubuntu-18-x64 python3 symlink

### DIFF
--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -44,6 +44,7 @@ RUN cd /tmp \
     && cd / \
     && rm -rf /tmp/Python-3.10.12* \
     && ln -sf /usr/local/bin/python3.10 /usr/local/bin/python \
+    && ln -sf /usr/local/bin/python3.10 /usr/local/bin/python3 \
     && /usr/local/bin/python3.10 --version
 
 # Install Go and ensure system Python tools work


### PR DESCRIPTION
In ubuntu-18-x64 we build Python 3.10 from source and symlink it to python but not python3. This change also symlinks to python3 so that downstream CI tests where scripts try to use python3 don't fail to find pip and/or run into other python3 command related issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
