### PR TITLE
Enable Windows-on-ARM64 builds by fixing arch detection and adding Windows ARM CI

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-14, macos-15, windows-2025]
+        host: [ubuntu-22.04, macos-14, macos-15, windows-2025, windows-11-arm]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -658,6 +658,11 @@ COMPILERS = {
                     '-Ax64',
                 ],
             },
+            'armv8': {
+                'cmake_args': [
+                    '-AARM64',
+                ],
+            },
         },
     },
     'ndk': {
@@ -684,6 +689,7 @@ for arch in ARCHS.keys():
 PLATFORMS = {
     'windows-x86': {},
     'windows-x64': {},
+    'windows-armv8': {},
     'macos-x64': {},
     'macos-armv8': {},
     'freebsd-x64': {},
@@ -704,7 +710,7 @@ PLATFORMS = {
 }
 
 # Windows
-for arch in ['x86', 'x64']:
+for arch in ['x86', 'x64','armv8']:
     canonical_windows = 'windows-{}'.format(arch)
     for alias in ARCHS[arch].get('aliases', []):
         alias_windows = 'windows-{}'.format(alias)

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -710,7 +710,7 @@ PLATFORMS = {
 }
 
 # Windows
-for arch in ['x86', 'x64','armv8']:
+for arch in ['x86', 'x64', 'armv8']:
     canonical_windows = 'windows-{}'.format(arch)
     for alias in ARCHS[arch].get('aliases', []):
         alias_windows = 'windows-{}'.format(alias)

--- a/builder/core/host.py
+++ b/builder/core/host.py
@@ -4,6 +4,7 @@
 from builder.core.data import ARCHS, HOSTS, PKG_TOOLS
 
 import os
+import platform
 import re
 import sys
 
@@ -33,6 +34,10 @@ def current_arch():
             if arch == 'aarch64':
                 arch = 'armv8'
             return arch
+    elif current_os() == 'windows':
+        machine = platform.machine().lower()
+        if machine in ('arm64'):
+            return 'armv8'
     return 'x64' if sys.maxsize > 2**32 else 'x86'
 
 


### PR DESCRIPTION
*Issue*

Several AWS CRT projects rely on `builder.pyz` for builds (e.g., `aws-c-event-stream`). Today, when `builder.pyz` runs on a Windows ARM64 machine, architecture detection reports `x64`, which blocks native ARM64 workflows and prevents downstream projects from producing native ARM64 artifacts.

Adding Windows ARM64 support here improves developer experience and reduces dependency on x64 emulation for Windows-on-ARM platforms.

*Description of changes:*

1) Windows ARM64 host detection (`builder/core/host.py`)
- Use `platform.machine()` on Windows to detect ARM64 
- Map Windows ARM64 to the builder’s canonical internal arch: `armv8`

2) Windows ARM64 platform + compiler support (`builder/core/data.py`)
- Add `armv8` to MSVC architectures with CMake args `-AARM64`
- Add `windows-armv8` to the platform set
- Extend Windows alias generation so the following map to `windows-armv8`:
  - `windows-arm64`, `windows-arm64v8`, `windows-arm64v8a`, `windows-aarch64`

3) CI coverage (`.github/workflows/sanity-test.yml`)
- Add a Windows ARM runner (`windows-11-arm`) to the sanity test matrix to ensure this code path is exercised in CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
