### PR TITLE
Drop CPython 3.8 from manylinux2014

### DIFF
--- a/.github/docker-images/manylinux2014-x64/Dockerfile
+++ b/.github/docker-images/manylinux2014-x64/Dockerfile
@@ -17,8 +17,8 @@ RUN yum -y install sudo cmake3 \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN /opt/python/cp38-cp38/bin/python -m pip install --upgrade setuptools virtualenv \
-    && /opt/python/cp38-cp38/bin/python -m pip install --upgrade awscli \
+RUN /opt/python/cp39-cp39/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp39-cp39/bin/python -m pip install --upgrade awscli \
     && ln -s `find /opt -name aws` /usr/local/bin/aws \
     && which aws \
     && aws --version

--- a/.github/docker-images/manylinux2014-x86/Dockerfile
+++ b/.github/docker-images/manylinux2014-x86/Dockerfile
@@ -13,8 +13,8 @@ RUN yum -y install sudo \
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################
-RUN /opt/python/cp38-cp38/bin/python -m pip install --upgrade setuptools virtualenv \
-    && /opt/python/cp38-cp38/bin/python -m pip install --upgrade awscli \
+RUN /opt/python/cp39-cp39/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp39-cp39/bin/python -m pip install --upgrade awscli \
     && ln -s `find /opt -name aws` /usr/local/bin/aws \
     && which aws \
     && aws --version


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/pypa/manylinux/issues/1882

*Description of changes:*

Use Python 3.9 in manylinux2014-x64 and manylinux2014-x86.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
