### PR TITLE
Loosen compiler version restriction

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-22.04, macos-14, macos-15, windows-2025]
+        host: [ubuntu-22.04, macos-14, macos-15, macos-26, windows-2025]
     needs: package
     runs-on: ${{ matrix.host }}
     steps:
@@ -141,6 +141,31 @@ jobs:
       if: startsWith(matrix.host, 'windows')
       run: |
         python builder.pyz build --project aws-c-common
+
+  # If we explicitly set the compiler version, the compiler version should be in the 
+  # version list.
+  compiler_version_explicit_out_of_list_fails:
+    name: Explicit appleclang-21 fails
+    needs: package
+    runs-on: macos-26
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v4
+
+    - name: Install builder
+      uses: actions/download-artifact@v4
+      with:
+        name: builder
+        path: .
+
+    - name: Build with explicit appleclang-21 should fail
+      run: |
+        if python3 builder.pyz build --project tests --compiler=appleclang-21; then
+          echo "ERROR: Expected builder to fail with appleclang-21 but it succeeded"
+          exit 1
+        else
+          echo "PASSED: builder correctly rejected explicit appleclang-21 (not in known versions list)"
+        fi
 
   # Make sure cross compiling works
   cross_compile:
@@ -387,6 +412,7 @@ jobs:
     needs:
     - unit_test
     - sanity_test
+    - compiler_version_explicit_out_of_list_fails
     - cross_compile
     - compilers
     - release_notes

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -492,8 +492,10 @@ COMPILERS = {
     'appleclang': {
         'hosts': ['macos'],
         'targets': ['macos', 'ios', 'tvos', 'watchos'],
+
         'versions': {
             'default': {},
+
             '11': {},
             '12': {},
             '13': {},

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -492,10 +492,8 @@ COMPILERS = {
     'appleclang': {
         'hosts': ['macos'],
         'targets': ['macos', 'ios', 'tvos', 'watchos'],
-        'default': {},
         'versions': {
             'default': {},
-            'latest': {},
             '11': {},
             '12': {},
             '13': {},

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -492,10 +492,10 @@ COMPILERS = {
     'appleclang': {
         'hosts': ['macos'],
         'targets': ['macos', 'ios', 'tvos', 'watchos'],
-
+        'default': {},
         'versions': {
             'default': {},
-
+            'latest': {},
             '11': {},
             '12': {},
             '13': {},

--- a/builder/core/spec.py
+++ b/builder/core/spec.py
@@ -23,7 +23,7 @@ def _compiler_meets_minimum_version(compiler_version, compiler):
     versions = [v for v in compiler['versions'].keys() if (v != 'default' and v != 'latest')]
 
     # Filter out versions that cannot be parsed
-    versions = [v for v in versions if _parse_version(v) is not None]
+    versions = [_parse_version(v) for v in versions if _parse_version(v) is not None]
 
     # Versions are not specified or none are parseable, return True
     if not versions:
@@ -31,7 +31,7 @@ def _compiler_meets_minimum_version(compiler_version, compiler):
 
     # Sort and find the minimum version
     versions.sort()
-    minimal_version = _parse_version(versions[0])
+    minimal_version = versions[0]
 
     # Parse compiler_version
     parsed_compiler = _parse_version(compiler_version)

--- a/builder/core/spec.py
+++ b/builder/core/spec.py
@@ -22,6 +22,9 @@ def _compiler_meets_minimum_version(compiler_version, compiler):
     # Sort compiler version keys and find the lowest (minimal) version
     versions = [v for v in compiler['versions'].keys() if (v != 'default' and v != 'latest')]
 
+    # Filter out versions that cannot be parsed
+    versions = [v for v in versions if _parse_version(v) is not None]
+
     # Versions are not specified or none are parseable, return True
     if not versions:
         return True

--- a/builder/core/spec.py
+++ b/builder/core/spec.py
@@ -7,7 +7,51 @@ from builder.core.data import *
 from builder.core.host import current_host, current_os, current_arch, normalize_arch
 
 
-def validate_spec(build_spec):
+def _parse_version(version_str):
+    """Parse a version string into a list of integers for comparison.
+    The version string can be in format X, X.Y, X.Y.Z, etc."""
+    try:
+        return [int(x) for x in version_str.split('.')]
+    except (ValueError, AttributeError):
+        return None
+
+
+def _compiler_meets_minimum_version(compiler_version, compiler):
+    """Check if the compiler version meets the minimum supported version requirement.
+    Returns True if compiler_version >= minimum known version, False otherwise."""
+    # Sort compiler version keys and find the lowest (minimal) version
+    versions = [v for v in compiler['versions'].keys() if (v != 'default' and v != 'latest')]
+
+    # Filter out versions that cannot be parsed
+    versions = [v for v in versions if _parse_version(v) is not None]
+
+    # Versions are not specified or none are parseable, return True
+    if not versions:
+        return True
+
+    # Sort and find the minimum version
+    versions.sort()
+    minimal_version = _parse_version(versions[0])
+
+    # Parse compiler_version
+    parsed_compiler = _parse_version(compiler_version)
+    if parsed_compiler is None:
+        return False
+
+    # Compare using Python's native list comparison
+    return parsed_compiler >= minimal_version
+
+
+def validate_spec(build_spec, allow_higher_version=False):
+    """Validate the build spec against known hosts, targets, architectures, and compilers.
+
+    Args:
+        allow_higher_version: If True, skip validation for compiler versions higher than
+            what's in the known versions list (e.g. when a newer compiler is detected on
+            the system), but still assert that the version is not lower than the minimum
+            supported version. If False, the compiler version must exactly match one of
+            the known versions.
+    """
 
     assert build_spec.host in HOSTS, "Host name {} is invalid".format(
         build_spec.host)
@@ -21,8 +65,15 @@ def validate_spec(build_spec):
         build_spec.compiler)
     compiler = COMPILERS[build_spec.compiler]
 
-    assert build_spec.compiler_version in compiler['versions'], "Compiler version {} is invalid for compiler {}".format(
-        build_spec.compiler_version, build_spec.compiler)
+    if not allow_higher_version:
+        assert build_spec.compiler_version in compiler['versions'], "Compiler version {} is invalid for compiler {}".format(
+            build_spec.compiler_version, build_spec.compiler)
+    else:
+        assert _compiler_meets_minimum_version(
+            build_spec.compiler_version, compiler), \
+            "Compiler version {} is lower than the minimum supported " \
+            "version for compiler {}".format(
+                build_spec.compiler_version, build_spec.compiler)
 
     supported_hosts = compiler['hosts']
     assert build_spec.host in supported_hosts or current_os() in supported_hosts, "Compiler {} does not support host {}".format(
@@ -81,6 +132,8 @@ class BuildSpec(object):
         if self.downstream:
             self.name += "-downstream"
 
+        # Strict validation at construction time: compiler version must exactly match
+        # a known version in the data dictionary.
         validate_spec(self)
 
     def __str__(self):
@@ -90,6 +143,13 @@ class BuildSpec(object):
         return self.name
 
     def update_compiler(self, compiler, compiler_version):
+        """Update the spec's compiler and version after resolving the system toolchain.
+
+        This is called after the Toolchain detects the actual compiler installed on the
+        system, and validates the detected compiler version.
+        The function allows the spec to be set to a higher version than what's in the
+        known versions list, but still rejects versions below the minimum supported.
+        """
         self.compiler = compiler
         self.compiler_version = compiler_version
 
@@ -98,4 +158,7 @@ class BuildSpec(object):
         if self.downstream:
             self.name += "-downstream"
 
-        validate_spec(self)
+        # Validate with allow_higher_version=True to allow system-detected compiler
+        # newer than what's in our known versions list. We still reject versions
+        # below the minimum supported version.
+        validate_spec(self, allow_higher_version=True)

--- a/builder/core/spec.py
+++ b/builder/core/spec.py
@@ -22,9 +22,6 @@ def _compiler_meets_minimum_version(compiler_version, compiler):
     # Sort compiler version keys and find the lowest (minimal) version
     versions = [v for v in compiler['versions'].keys() if (v != 'default' and v != 'latest')]
 
-    # Filter out versions that cannot be parsed
-    versions = [v for v in versions if _parse_version(v) is not None]
-
     # Versions are not specified or none are parseable, return True
     if not versions:
         return True

--- a/builder/main.py
+++ b/builder/main.py
@@ -294,6 +294,7 @@ def main():
         sys.exit(1)
 
     if env.config.get('needs_compiler', True):
+        # Resolve the actual compiler from the system toolchain and update the spec.
         env.toolchain = Toolchain(spec=env.spec)
         env.spec.update_compiler(env.toolchain.compiler, env.toolchain.compiler_version)
         if env.spec.compiler == 'default' or env.spec.compiler_version == 'default':

--- a/builder/main.py
+++ b/builder/main.py
@@ -97,8 +97,7 @@ def run_build(env):
 def default_spec(env):
     target, arch = current_platform().split('-')
     host = current_host()
-    compiler, version = Toolchain.default_compiler(target, arch)
-    return BuildSpec(host=host, compiler=compiler, compiler_version='{}'.format(version), target=target, arch=arch)
+    return BuildSpec(host=host, target=target, arch=arch)
 
 
 def inspect_host(spec):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Loosens the compiler version validation so that system-detected compiler versions no longer need to exactly match a version listed in `data.py`. Instead, any version at or above the minimum supported version is accepted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
