### PR TITLE
adding manylinux2_28 images

### DIFF
--- a/.github/docker-images/manylinux_2_28-aarch64/Dockerfile
+++ b/.github/docker-images/manylinux_2_28-aarch64/Dockerfile
@@ -1,0 +1,35 @@
+# See: https://github.com/pypa/manylinux
+# and: https://github.com/pypa/python-manylinux-demo
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28)
+FROM quay.io/pypa/manylinux_2_28_aarch64
+
+###############################################################################
+# Basics
+###############################################################################
+# cmake and ctest come pre-installed via pipx in manylinux_2_28
+RUN yum -y install sudo \
+    && yum clean all \
+    && cmake --version \
+    && ctest --version
+
+###############################################################################
+# Python/AWS CLI
+###############################################################################
+RUN /opt/python/cp39-cp39/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp39-cp39/bin/python -m pip install --upgrade awscli \
+    && ln -s `find /opt -name aws` /usr/local/bin/aws \
+    && which aws \
+    && aws --version
+
+###############################################################################
+# nodejs/npm
+###############################################################################
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+RUN yum -y install nodejs && node --version
+
+###############################################################################
+# Install entrypoint
+###############################################################################
+ADD entrypoint.sh /usr/local/bin/builder
+RUN chmod a+x /usr/local/bin/builder
+ENTRYPOINT ["/usr/local/bin/builder"]

--- a/.github/docker-images/manylinux_2_28-x64/Dockerfile
+++ b/.github/docker-images/manylinux_2_28-x64/Dockerfile
@@ -1,0 +1,31 @@
+# See: https://github.com/pypa/manylinux
+# and: https://github.com/pypa/python-manylinux-demo
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28)
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+###############################################################################
+# Basics
+###############################################################################
+# cmake and ctest come pre-installed via pipx in manylinux_2_28
+RUN yum -y install sudo \
+    # used in java release pipeline
+    maven \
+    && yum clean all \
+    && cmake --version \
+    && ctest --version
+
+###############################################################################
+# Python/AWS CLI
+###############################################################################
+RUN /opt/python/cp39-cp39/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp39-cp39/bin/python -m pip install --upgrade awscli \
+    && ln -s `find /opt -name aws` /usr/local/bin/aws \
+    && which aws \
+    && aws --version
+
+###############################################################################
+# Install entrypoint
+###############################################################################
+ADD entrypoint.sh /usr/local/bin/builder
+RUN chmod a+x /usr/local/bin/builder
+ENTRYPOINT ["/usr/local/bin/builder"]

--- a/.github/docker-images/manylinux_2_28-x86/Dockerfile
+++ b/.github/docker-images/manylinux_2_28-x86/Dockerfile
@@ -1,0 +1,31 @@
+# See: https://github.com/pypa/manylinux
+# and: https://github.com/pypa/python-manylinux-demo
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28)
+FROM quay.io/pypa/manylinux_2_28_i686
+
+###############################################################################
+# Basics
+###############################################################################
+# cmake and ctest come pre-installed via pipx in manylinux_2_28
+RUN yum -y install sudo \
+    # used in java release pipeline
+    maven \
+    && yum clean all \
+    && cmake --version \
+    && ctest --version
+
+###############################################################################
+# Python/AWS CLI
+###############################################################################
+RUN /opt/python/cp39-cp39/bin/python -m pip install --upgrade setuptools virtualenv \
+    && /opt/python/cp39-cp39/bin/python -m pip install --upgrade awscli \
+    && ln -s `find /opt -name aws` /usr/local/bin/aws \
+    && which aws \
+    && aws --version
+
+###############################################################################
+# Install entrypoint
+###############################################################################
+ADD entrypoint.sh /usr/local/bin/builder
+RUN chmod a+x /usr/local/bin/builder
+ENTRYPOINT ["/usr/local/bin/builder"]

--- a/.github/docker-images/node-18-linux-x64/Dockerfile
+++ b/.github/docker-images/node-18-linux-x64/Dockerfile
@@ -1,0 +1,38 @@
+FROM almalinux:8
+
+###############################################################################
+# Install prereqs
+###############################################################################
+RUN yum -y update \
+    && yum -y install \
+    tar \
+    git \
+    curl \
+    sudo \
+    # Python
+    python3 \
+    python3-devel \
+    python3-pip \
+    # Build tools
+    make \
+    gcc \
+    gcc-c++ \
+    cmake \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && cmake --version \
+    && ctest --version
+
+###############################################################################
+# Python/AWS CLI
+###############################################################################
+RUN python3 -m pip install --upgrade setuptools virtualenv \
+    && python3 -m pip install --upgrade awscli \
+    && aws --version
+
+###############################################################################
+# Install entrypoint
+###############################################################################
+ADD entrypoint.sh /usr/local/bin/builder
+RUN chmod a+x /usr/local/bin/builder
+ENTRYPOINT ["/usr/local/bin/builder"]

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -84,6 +84,9 @@ jobs:
         - name: manylinux2014-x86
         - name: manylinux2014-x64
         - name: manylinux2014-aarch64
+        - name: manylinux_2_28-x86
+        - name: manylinux_2_28-x64
+        - name: manylinux_2_28-aarch64
         - name: musllinux-1-1-aarch64
         - name: musllinux-1-1-x64
         - name: al2012-x64

--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -99,6 +99,7 @@ jobs:
         - name: ubuntu-22-x64
         - name: ubuntu-22-msan-x64
         - name: node-10-linux-x64
+        - name: node-18-linux-x64
         - name: swift-5-al2-x64
         - name: swift-5-ubuntu-x64
         - name: rhel8-x64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -85,6 +85,7 @@ jobs:
         - name: ubuntu-22-x64
         - name: ubuntu-22-msan-x64
         - name: node-10-linux-x64
+        - name: node-18-linux-x64
         - name: swift-5-al2-x64
         - name: swift-5-ubuntu-x64
         - name: rhel8-x64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -70,6 +70,9 @@ jobs:
         - name: manylinux2014-x86
         - name: manylinux2014-x64
         - name: manylinux2014-aarch64
+        - name: manylinux_2_28-x86
+        - name: manylinux_2_28-x64
+        - name: manylinux_2_28-aarch64
         - name: musllinux-1-1-aarch64
         - name: musllinux-1-1-x64
         - name: al2012-x64

--- a/builder/core/host.py
+++ b/builder/core/host.py
@@ -86,9 +86,8 @@ def current_host():
                 if os.path.exists('/opt/python/cp39-cp39'):
                     return 'manylinux'
                 return 'centos'
-            # AlmaLinux 8 is the base for manylinux_2_28 and other RHEL-compatible images
-            if _file_contains('/etc/redhat-release', 'AlmaLinux release 8.') \
-                    or _file_contains('/etc/os-release', 'ID="almalinux"'):
+            # AlmaLinux 8 is a RHEL rebuild hence reusing the 'rhel' host (same DNF).
+            if _file_contains('/etc/redhat-release', 'AlmaLinux release 8.'):
                 if os.path.exists('/opt/python/cp39-cp39'):
                     return 'manylinux'
                 return 'rhel'

--- a/builder/core/host.py
+++ b/builder/core/host.py
@@ -86,6 +86,12 @@ def current_host():
                 if os.path.exists('/opt/python/cp39-cp39'):
                     return 'manylinux'
                 return 'centos'
+            # AlmaLinux 8 is the base for manylinux_2_28 and other RHEL-compatible images
+            if _file_contains('/etc/redhat-release', 'AlmaLinux release 8.') \
+                    or _file_contains('/etc/os-release', 'ID="almalinux"'):
+                if os.path.exists('/opt/python/cp39-cp39'):
+                    return 'manylinux'
+                return 'rhel'
             if _file_contains('/etc/lsb-release', 'Ubuntu'):
                 return 'ubuntu'
             if _file_contains('/etc/os-release', 'Debian'):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adding `manylinux2_28` x86, x64, aarch64 image.
- Adding `node-18-linux-x64` image with base image as `Almalinux8`.
- Using default cmake and ctest of the docker image




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
