### PR TITLE
Bake ubuntu-toolchain-r ppa into ubuntu

### DIFF
--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update -qq \
     ca-certificates \
     && apt-get clean
 
+# ubuntu-toolchain-r PPA provides newer gcc versions
+RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
+
 # Install dependencies for building Python from source
 RUN apt-get update \
     && apt-get -y install \

--- a/.github/docker-images/ubuntu-20-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-20-x64/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update -qq \
     ca-certificates \
     && apt-get clean
 
+# ubuntu-toolchain-r PPA provides newer gcc versions
+RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
+
 # Add the longsleep/golang-backports PPA
 RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:longsleep/golang-backports && apt-get update
 

--- a/.github/docker-images/ubuntu-22-abi-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-22-abi-x64/Dockerfile
@@ -39,6 +39,9 @@ RUN apt-get update -qq \
     ca-certificates \
     && apt-get clean
 
+# ubuntu-toolchain-r PPA provides newer gcc versions
+RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
+
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################

--- a/.github/docker-images/ubuntu-22-msan-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-22-msan-x64/Dockerfile
@@ -28,6 +28,9 @@ RUN apt-get update -qq \
     golang-go \
     && apt-get clean
 
+# ubuntu-toolchain-r PPA provides newer gcc versions
+RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
+
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################

--- a/.github/docker-images/ubuntu-22-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-22-x64/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update -qq \
     golang-go \
     && apt-get clean
 
+# ubuntu-toolchain-r PPA provides newer gcc versions
+RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
+
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -127,7 +127,7 @@ HOSTS = {
         # need ld and make and such
         'packages': ['build-essential'],
         'pkg_setup': [
-            'bash -c "grep -q ubuntu-toolchain-r /etc/apt/sources.list.d/*.list 2>/dev/null || apt-add-repository -y ppa:ubuntu-toolchain-r/test"',
+            ['bash', '-c', 'grep -q ubuntu-toolchain-r /etc/apt/sources.list.d/*.list 2>/dev/null || apt-add-repository -y ppa:ubuntu-toolchain-r/test'],
         ],
         'pkg_update': 'apt-get -qq update -y',
         'pkg_install': 'apt-get -qq install -y',

--- a/builder/core/data.py
+++ b/builder/core/data.py
@@ -127,7 +127,7 @@ HOSTS = {
         # need ld and make and such
         'packages': ['build-essential'],
         'pkg_setup': [
-            'apt-add-repository -y ppa:ubuntu-toolchain-r/test',
+            'bash -c "grep -q ubuntu-toolchain-r /etc/apt/sources.list.d/*.list 2>/dev/null || apt-add-repository -y ppa:ubuntu-toolchain-r/test"',
         ],
         'pkg_update': 'apt-get -qq update -y',
         'pkg_install': 'apt-get -qq install -y',


### PR DESCRIPTION
*Issue #, if available:*
Currently, `apt-add-repository -y ppa:ubuntu-toolchain-r/test` runs each time an Ubuntu image is used in CI (it provides newer versions of gcc). It seems we started hitting launchpad API limits because multiple CI jobs are executing it in parallel.

*Description of changes:*
Bake ubuntu-toolchain-r PPA into ubuntu images. The PPA itself (ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu) is served by a CDN and should be reliable, so compilers are not added into the images.

`apt-add-repository -y ppa:ubuntu-toolchain-r/test'` will still be run in runtime if aws-crt-builder is executed on Ubuntu without this PPA, i.e. not on one of the images provided by it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
