### PR TITLE
Auto-release based on tag

### DIFF
--- a/.github/actions/auto-release/action.yml
+++ b/.github/actions/auto-release/action.yml
@@ -54,24 +54,25 @@ runs:
     - name: Resolve previous release tag
       id: resolve
       shell: bash
-      env:
-        VERSION_FILE: ${{ inputs.version-file }}
       run: |
-        # Walk tags nearest-first and skip any whose VERSION isn't a plain
-        # major.minor.patch -- a manually-cut beta/rc tag (non-numeric
-        # suffix) must not block automated releases forever. The next run
-        # just looks past it to the last real stable release and bumps from
-        # there; the beta tag itself is left alone.
+        # Walk tags nearest-first and skip any whose NAME isn't "vMAJOR.MINOR.PATCH"
+        # -- a manually-cut beta/rc tag (non-numeric suffix) must not block
+        # automated releases forever. The next run just looks past it to the
+        # last real stable release and bumps from there; the beta tag itself
+        # is left alone. The version comes from the TAG NAME, never from a
+        # file's content at that tag -- a previous release's VERSION file may
+        # not exist, may be stale, or may not even be the convention this repo
+        # used at the time; the tag is the one thing guaranteed to reflect
+        # what was actually released.
         for TAG in $(git tag --sort=-creatordate --merged HEAD); do
-          VERSION="$(git show "${TAG}:${VERSION_FILE}" 2>/dev/null | tr -d '[:space:]')"
-          if [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+          if [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Previous release tag: $TAG"
             echo "previous_tag=${TAG}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Skipping tag '$TAG': '${VERSION_FILE}' is '${VERSION:-<unreadable>}', not major.minor.patch."
+          echo "Skipping tag '$TAG': not of the form vMAJOR.MINOR.PATCH."
         done
-        echo "ERROR: no previous release tag with a valid '${VERSION_FILE}' found; cannot compute a release." >&2
+        echo "ERROR: no previous release tag of the form vMAJOR.MINOR.PATCH found; cannot compute a release." >&2
         exit 1
 
     - name: Check ABI (previous release vs this ref)

--- a/.github/actions/auto-release/scripts/compute-version-bump.sh
+++ b/.github/actions/auto-release/scripts/compute-version-bump.sh
@@ -11,10 +11,15 @@
 # Inputs (env):
 #   GH_TOKEN         token with pull-requests: read, used by `gh pr list`
 #   REPO             "owner/repo", for `gh pr list --repo`
-#   PREVIOUS_TAG     the previous release tag (comparison base)
+#   PREVIOUS_TAG     the previous release tag, "vMAJOR.MINOR.PATCH" (the
+#                    previously released version is parsed from this name,
+#                    never read from a file's content at that tag)
 #   ABI_LABEL        "patch" | "minor" | "needs-review" | "" -- output of the
 #                    check-abi action (see its gate.sh for how this is chosen)
-#   VERSION_FILE     path (relative to repo root) holding "major.minor.patch"
+#   VERSION_FILE     path (relative to repo root) holding the current version
+#                    at HEAD. Must exist and match the previous tag's version
+#                    -- if it drifts, we bail rather than silently release from
+#                    an inconsistent state.
 #   MINOR_PR_LABEL   PR label that forces a minor bump
 #
 # Outputs (appended to $GITHUB_OUTPUT):
@@ -101,23 +106,40 @@ if [[ "${ABI_LABEL:-}" != "patch" && "${ABI_LABEL:-}" != "minor" ]]; then
   exit 1
 fi
 
-# --- Read the previously released version -----------------------------------
-PREVIOUS_VERSION="$(git show "${PREVIOUS_TAG}:${VERSION_FILE}" 2>/dev/null | tr -d '[:space:]')"
-if [[ -z "$PREVIOUS_VERSION" ]]; then
-  echo "ERROR: could not read '${VERSION_FILE}' at tag '${PREVIOUS_TAG}'." >&2
+# --- Derive the previously released version from the TAG NAME ---------------
+# Never from a file's content at that tag: an older release may predate
+# VERSION_FILE existing, or may have used a different convention. The tag
+# name is the one thing guaranteed to reflect what was actually released.
+if ! [[ "$PREVIOUS_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "ERROR: '${PREVIOUS_TAG}' is not of the form vMAJOR.MINOR.PATCH." >&2
   summary ""
-  summary "**FAILED: could not read \`${VERSION_FILE}\` at tag \`${PREVIOUS_TAG}\`.**"
-  exit 1
-fi
-if ! [[ "$PREVIOUS_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-  echo "ERROR: '${VERSION_FILE}' at '${PREVIOUS_TAG}' is not major.minor.patch (got '${PREVIOUS_VERSION}')." >&2
-  summary ""
-  summary "**FAILED: \`${VERSION_FILE}\` at \`${PREVIOUS_TAG}\` is not major.minor.patch (got \`${PREVIOUS_VERSION}\`).**"
+  summary "**FAILED: \`${PREVIOUS_TAG}\` is not of the form \`vMAJOR.MINOR.PATCH\`.**"
   exit 1
 fi
 MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"
 PATCH="${BASH_REMATCH[3]}"
+PREVIOUS_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+# --- Drift check: VERSION_FILE at HEAD must match PREVIOUS_TAG's version -----
+# The tag is the source of truth for what was released. If the file on HEAD
+# says something else, someone edited it out of sync and we're one step away
+# from releasing from a state that misrepresents the previous version. Bail.
+if [[ ! -f "$VERSION_FILE" ]]; then
+  echo "ERROR: '${VERSION_FILE}' does not exist at HEAD; add it (matching '${PREVIOUS_VERSION}') and retry." >&2
+  summary ""
+  summary "**FAILED: \`${VERSION_FILE}\` does not exist at HEAD.**"
+  exit 1
+fi
+CURRENT_FILE_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
+if [[ "$CURRENT_FILE_VERSION" != "$PREVIOUS_VERSION" ]]; then
+  echo "ERROR: drift detected. '${VERSION_FILE}' at HEAD says '${CURRENT_FILE_VERSION}'," >&2
+  echo "       but the previous release tag '${PREVIOUS_TAG}' implies '${PREVIOUS_VERSION}'." >&2
+  echo "       Reconcile before releasing." >&2
+  summary ""
+  summary "**FAILED: \`${VERSION_FILE}\` (\`${CURRENT_FILE_VERSION}\`) drifted from the previous release tag \`${PREVIOUS_TAG}\` (\`${PREVIOUS_VERSION}\`). Reconcile before releasing.**"
+  exit 1
+fi
 
 # --- Rule 2 -------------------------------------------------------------------
 BUMP=""

--- a/.github/actions/auto-release/scripts/compute-version-bump.sh
+++ b/.github/actions/auto-release/scripts/compute-version-bump.sh
@@ -16,10 +16,10 @@
 #                    never read from a file's content at that tag)
 #   ABI_LABEL        "patch" | "minor" | "needs-review" | "" -- output of the
 #                    check-abi action (see its gate.sh for how this is chosen)
-#   VERSION_FILE     path (relative to repo root) holding the current version
-#                    at HEAD. Must exist and match the previous tag's version
-#                    -- if it drifts, we bail rather than silently release from
-#                    an inconsistent state.
+#   VERSION_FILE     path (relative to repo root) where the current version
+#                    at HEAD is expected. If present, it must match the
+#                    previous tag's version (drift check). If absent, this
+#                    release creates it -- the file is not a hard prerequisite.
 #   MINOR_PR_LABEL   PR label that forces a minor bump
 #
 # Outputs (appended to $GITHUB_OUTPUT):
@@ -121,24 +121,23 @@ MINOR="${BASH_REMATCH[2]}"
 PATCH="${BASH_REMATCH[3]}"
 PREVIOUS_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 
-# --- Drift check: VERSION_FILE at HEAD must match PREVIOUS_TAG's version -----
-# The tag is the source of truth for what was released. If the file on HEAD
-# says something else, someone edited it out of sync and we're one step away
-# from releasing from a state that misrepresents the previous version. Bail.
-if [[ ! -f "$VERSION_FILE" ]]; then
-  echo "ERROR: '${VERSION_FILE}' does not exist at HEAD; add it (matching '${PREVIOUS_VERSION}') and retry." >&2
-  summary ""
-  summary "**FAILED: \`${VERSION_FILE}\` does not exist at HEAD.**"
-  exit 1
-fi
-CURRENT_FILE_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
-if [[ "$CURRENT_FILE_VERSION" != "$PREVIOUS_VERSION" ]]; then
-  echo "ERROR: drift detected. '${VERSION_FILE}' at HEAD says '${CURRENT_FILE_VERSION}'," >&2
-  echo "       but the previous release tag '${PREVIOUS_TAG}' implies '${PREVIOUS_VERSION}'." >&2
-  echo "       Reconcile before releasing." >&2
-  summary ""
-  summary "**FAILED: \`${VERSION_FILE}\` (\`${CURRENT_FILE_VERSION}\`) drifted from the previous release tag \`${PREVIOUS_TAG}\` (\`${PREVIOUS_VERSION}\`). Reconcile before releasing.**"
-  exit 1
+# --- Drift check: if VERSION_FILE exists at HEAD, it must match PREVIOUS_TAG -
+# The tag is the source of truth for what was released. If the file exists on
+# HEAD but says something else, someone edited it out of sync and we're one
+# step away from releasing from a state that misrepresents the previous
+# version. If the file doesn't exist yet (this repo is adopting a VERSION
+# file for the first time via this release), that's fine -- cut-release.sh
+# will create it with the newly computed version.
+if [[ -f "$VERSION_FILE" ]]; then
+  CURRENT_FILE_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
+  if [[ "$CURRENT_FILE_VERSION" != "$PREVIOUS_VERSION" ]]; then
+    echo "ERROR: drift detected. '${VERSION_FILE}' at HEAD says '${CURRENT_FILE_VERSION}'," >&2
+    echo "       but the previous release tag '${PREVIOUS_TAG}' implies '${PREVIOUS_VERSION}'." >&2
+    echo "       Reconcile before releasing." >&2
+    summary ""
+    summary "**FAILED: \`${VERSION_FILE}\` (\`${CURRENT_FILE_VERSION}\`) drifted from the previous release tag \`${PREVIOUS_TAG}\` (\`${PREVIOUS_VERSION}\`). Reconcile before releasing.**"
+    exit 1
+  fi
 fi
 
 # --- Rule 2 -------------------------------------------------------------------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We attempted to release based on version files inside the repository. For the first release this does not hold true since many of the crt repos do not have version files. This makes sure we can also auto release based on the github tag.

If version file exists in the previous version, we check that it is correct to ensure there is no drift between the version recorded within vs version the lib is declared to be.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
