### PR TITLE
Change deploy key format

### DIFF
--- a/.github/actions/auto-release/README.md
+++ b/.github/actions/auto-release/README.md
@@ -52,12 +52,13 @@ Same as `check-abi` (this action calls it internally):
 - **Checkout with `fetch-depth: 0`** so tag history is available.
 - **Grant `contents: write`** so this action can create the release.
 - **Register a deploy key with write access** on the repo (Settings -> Deploy
-  keys), and store its private half in AWS Secrets Manager at
-  `deploy-key-secret-id`. This is what actually authorizes the push to the
-  default branch -- the job's own `github.token` never touches it, avoiding a
-  standing broad-scope PAT (same approach as aws-crt-swift's
-  `update-version.yml`: a repo-scoped key fetched fresh each run, not a
-  long-lived secret sitting in a user/bot account).
+  keys), and store its material in AWS Secrets Manager at
+  `deploy-key-secret-id`. The SecretString is expected to be a JSON blob
+  with a `.private_key` field (the PEM-encoded private half of the deploy
+  key), which this action reads. This is what actually authorizes the push
+  to the default branch -- the job's own `github.token` never touches it,
+  avoiding a standing broad-scope PAT: the repo-scoped key is fetched fresh
+  each run, not a long-lived secret sitting in a user/bot account.
 
 ## Usage
 
@@ -101,7 +102,7 @@ jobs:
 | `builder-version` | no | `latest` | Builder version/channel; also the ABI docker image tag. `latest` tracks the most recent published builder release. |
 | `dry-run` | no | `false` | Compute and summarize the bump/version but write/commit/tag/publish nothing. |
 | `github-token` | no | `github.token` | Token used to read PR labels and create the release. |
-| `deploy-key-secret-id` | no | `aws-crt-bot/deploy-key/privatekey` | AWS Secrets Manager secret ID holding the private half of the deploy key used to push the version-bump commit and tag. |
+| `deploy-key-secret-id` | no | `github-deploy-key/<owner>/<repo>` | AWS Secrets Manager secret ID holding the deploy key for this repo. SecretString is a JSON blob whose `.private_key` field holds the PEM. |
 
 ### Outputs
 

--- a/.github/actions/auto-release/README.md
+++ b/.github/actions/auto-release/README.md
@@ -24,10 +24,15 @@ would produce far more releases than any of these libraries want.
 3. **Compute the next version** (see
    [`scripts/compute-version-bump.sh`](scripts/compute-version-bump.sh) for the
    exact precedence):
-   - No commits since the previous tag -> skip, no release cut.
+   - No commits since the previous tag -> skip, no release cut (clean no-op,
+     not an error).
    - ABI check returned `needs-review` (an API break -- callers fail to
      recompile) -> **fail**. Major bumps are never automated; cut that tag by
      hand.
+   - Any merged PR since the previous tag carries the major PR label
+     (`needs-review` by default) -> **fail**. Defense-in-depth: those PRs
+     shouldn't have been merged; if one slipped through, the release refuses
+     to tag a repo whose history contains an unresolved API break.
    - ABI check returned `minor` (a binary-only break) -> minor bump, no debate.
    - Otherwise, a merged PR since the previous tag labeled `minor` -> minor
      bump.
@@ -98,6 +103,7 @@ jobs:
 |-------|----------|---------|-------------|
 | `lib-name` | yes | — | Library name; maps to `lib<name>.so` for the ABI check. |
 | `version-file` | no | `VERSION` | Path to the file holding `major.minor.patch`. |
+| `major-pr-label` | no | `needs-review` | PR label that hard-fails the release if any merged PR since the previous tag carries it. Defense-in-depth against a label that shouldn't be merged in the first place. |
 | `minor-pr-label` | no | `minor` | PR label that forces a minor bump when the ABI is compatible. |
 | `builder-version` | no | `latest` | Builder version/channel; also the ABI docker image tag. `latest` tracks the most recent published builder release. |
 | `dry-run` | no | `false` | Compute and summarize the bump/version but write/commit/tag/publish nothing. |

--- a/.github/actions/auto-release/action.yml
+++ b/.github/actions/auto-release/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Path to the file holding the current released version as "major.minor.patch".'
     required: false
     default: 'VERSION'
+  major-pr-label:
+    description: 'PR label that hard-fails the release. PRs with this label should never be merged (there is a separate gate for that); this scan is defense-in-depth in case one slipped through.'
+    required: false
+    default: 'needs-review'
   minor-pr-label:
     description: 'PR label that forces a minor bump when the ABI is compatible.'
     required: false
@@ -92,6 +96,7 @@ runs:
         PREVIOUS_TAG: ${{ steps.resolve.outputs.previous_tag }}
         ABI_LABEL: ${{ steps.check_abi.outputs.label }}
         VERSION_FILE: ${{ inputs.version-file }}
+        MAJOR_PR_LABEL: ${{ inputs.major-pr-label }}
         MINOR_PR_LABEL: ${{ inputs.minor-pr-label }}
       run: bash "${GITHUB_ACTION_PATH}/scripts/compute-version-bump.sh"
 

--- a/.github/actions/auto-release/action.yml
+++ b/.github/actions/auto-release/action.yml
@@ -26,9 +26,9 @@ inputs:
     required: false
     default: ${{ github.token }}
   deploy-key-secret-id:
-    description: 'AWS Secrets Manager secret ID holding the private half of a deploy key registered (with write access) on this repository. Used to push the version-bump commit and tag directly to the default branch, the same way aws-crt-swift''s update-version.yml does -- a repo-scoped SSH key fetched fresh via the already-assumed CRT_CI_ROLE_ARN role, rather than a standing broad-scope PAT.'
+    description: 'AWS Secrets Manager secret ID holding the deploy key for this repository. The SecretString is expected to be a JSON blob with a `.private_key` field. Used to push the version-bump commit and tag directly to the default branch -- a repo-scoped SSH key fetched fresh via the already-assumed CRT_CI_ROLE_ARN role, rather than a standing broad-scope PAT.'
     required: false
-    default: 'aws-crt-bot/deploy-key/privatekey'
+    default: 'github-deploy-key/${{ github.repository }}'
 
 outputs:
   skip:

--- a/.github/actions/auto-release/scripts/compute-version-bump.sh
+++ b/.github/actions/auto-release/scripts/compute-version-bump.sh
@@ -20,6 +20,9 @@
 #                    at HEAD is expected. If present, it must match the
 #                    previous tag's version (drift check). If absent, this
 #                    release creates it -- the file is not a hard prerequisite.
+#   MAJOR_PR_LABEL   PR label that hard-fails the release (major bumps are
+#                    never automated). Defense-in-depth: PRs with this label
+#                    are not supposed to be merged in the first place.
 #   MINOR_PR_LABEL   PR label that forces a minor bump
 #
 # Outputs (appended to $GITHUB_OUTPUT):
@@ -32,6 +35,7 @@ set -uo pipefail
 
 PREVIOUS_TAG="${PREVIOUS_TAG:?PREVIOUS_TAG must be set}"
 VERSION_FILE="${VERSION_FILE:?VERSION_FILE must be set}"
+MAJOR_PR_LABEL="${MAJOR_PR_LABEL:?MAJOR_PR_LABEL must be set}"
 MINOR_PR_LABEL="${MINOR_PR_LABEL:?MINOR_PR_LABEL must be set}"
 REPO="${REPO:?REPO must be set}"
 [[ "$REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || {
@@ -90,6 +94,26 @@ if [[ "${ABI_LABEL:-}" == "needs-review" ]]; then
   echo "       never automated. Cut that tag yourself, then re-run this workflow." >&2
   summary ""
   summary "**FAILED: the ABI check returned \`needs-review\` -- an API break between \`${PREVIOUS_TAG}\` and this ref.**"
+  summary ""
+  summary "Major version bumps are never automated by this workflow. Cut the major tag manually, then re-run."
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  exit 1
+fi
+
+# --- Rule 1b ------------------------------------------------------------------
+# Defense-in-depth: PRs carrying the major PR label are gated from merging in
+# the first place, so this should never fire in practice. If it does (e.g. the
+# gate was bypassed), fail the release rather than tag a repo whose history
+# contains an API-breaking PR the maintainer hasn't manually resolved.
+MAJOR_PRS="$(prs_with_label "$MAJOR_PR_LABEL")" || {
+  echo "ERROR: 'gh pr list' failed while checking for '${MAJOR_PR_LABEL}'-labeled PRs." >&2
+  exit 1
+}
+if [[ -n "$MAJOR_PRS" ]]; then
+  echo "ERROR: PR(s) #${MAJOR_PRS} merged since ${PREVIOUS_TAG} carry the '${MAJOR_PR_LABEL}' label." >&2
+  echo "       Major version bumps are never automated. Cut that tag yourself, then re-run." >&2
+  summary ""
+  summary "**FAILED: PR(s) #${MAJOR_PRS} merged since \`${PREVIOUS_TAG}\` are labeled \`${MAJOR_PR_LABEL}\`.**"
   summary ""
   summary "Major version bumps are never automated by this workflow. Cut the major tag manually, then re-run."
   echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/auto-release/scripts/cut-release.sh
+++ b/.github/actions/auto-release/scripts/cut-release.sh
@@ -2,13 +2,15 @@
 #
 # cut-release.sh - Fetch a repo-scoped deploy key from AWS Secrets Manager,
 # use it to push the bumped VERSION file straight to the default branch over
-# SSH, then tag the new commit and create the GitHub Release. Same mechanism
-# as aws-crt-swift's update-version.yml: the key is fetched fresh each run
-# via the already-assumed CRT_CI_ROLE_ARN role, used once, never persisted
-# past the job, and authorized to push directly -- no PR/admin-merge needed.
+# SSH, then tag the new commit and create the GitHub Release. The key is
+# fetched fresh each run via the already-assumed CRT_CI_ROLE_ARN role, used
+# once, never persisted past the job, and authorized to push directly -- no
+# PR/admin-merge needed and no standing broad-scope PAT.
 #
 # Inputs (env):
-#   DEPLOY_KEY_SECRET_ID  Secrets Manager secret ID holding the private key
+#   DEPLOY_KEY_SECRET_ID  Secrets Manager secret ID whose SecretString is a
+#                          JSON blob for this repo's deploy key
+#                          (`.private_key` extracted below)
 #   GH_TOKEN        token used to create the release (gh release create)
 #   REPO            "owner/repo"
 #   VERSION_FILE    path to the version file to write NEW_VERSION into
@@ -62,8 +64,13 @@ fi
 trap 'rm -f ~/.ssh/deploy_key' EXIT
 
 mkdir -p ~/.ssh
+# The secret's SecretString is a JSON blob; we want just the .private_key field.
 aws secretsmanager get-secret-value --secret-id "$DEPLOY_KEY_SECRET_ID" \
-  --query SecretString --output text > ~/.ssh/deploy_key
+  --query SecretString --output text | jq -r .private_key > ~/.ssh/deploy_key
+if [[ ! -s ~/.ssh/deploy_key ]] || ! head -1 ~/.ssh/deploy_key | grep -q "BEGIN"; then
+  echo "ERROR: '${DEPLOY_KEY_SECRET_ID}' did not yield a private key (jq .private_key produced no key material)." >&2
+  exit 1
+fi
 chmod 600 ~/.ssh/deploy_key
 
 ssh-keyscan -H github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- aws-crt-swift key format that was previously used is not extensible for a reusable workflow for multiple repos, so this change attempts to make the format extensible. 
- adds a simple safety check to never release a "needs-review" PR (we also block merging a PR labeled needs-review so ideally we never hit it).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
