### PR TITLE
Improve actions to be informative

### DIFF
--- a/.github/actions/auto-release/scripts/cut-release.sh
+++ b/.github/actions/auto-release/scripts/cut-release.sh
@@ -90,7 +90,7 @@ git config user.email "aws-sdk-common-runtime@amazon.com"
 
 printf '%s\n' "$NEW_VERSION" > "$VERSION_FILE"
 git add "$VERSION_FILE"
-git commit -m "Release ${NEW_VERSION} (${BUMP})"
+git commit -m "chore(release): ${BUMP}-update to VERSION - ${NEW_VERSION}"
 git push origin "$DEFAULT_BRANCH"
 
 git tag -a "$NEW_TAG" -m "Release ${NEW_VERSION}"

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -137,19 +137,23 @@ runs:
         fi
         exit "$RC"
 
-    - name: Upload ABI report
+    - name: Upload ABI artifacts
       # Uploaded on every run (success or fail) so a surprising verdict can be
       # triaged symbol-by-symbol offline. abi_check.sh stages the abicc HTML
       # reports, the two .dump files, and the removed-constants list under
-      # $GITHUB_WORKSPACE/abi-report/ before exiting the container. The
-      # step is a no-op when the container exited before that stage ran.
+      # $GITHUB_WORKSPACE/abi-artifacts/ before exiting the container. The step
+      # is a no-op when the container exited before that stage ran.
+      #
+      # Retention: 7 days. Triage almost always happens within a few days of
+      # a surprising run; a stale artifact isn't useful anyway (dep HEADs have
+      # moved). Re-run the check-abi workflow to regenerate if needed later.
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: abi-report-${{ github.event.pull_request.number || github.run_id }}
-        path: ${{ github.workspace }}/abi-report
+        name: abi-artifacts-${{ github.event.pull_request.number || github.run_id }}
+        path: ${{ github.workspace }}/abi-artifacts
         if-no-files-found: ignore
-        retention-days: 30
+        retention-days: 7
 
     - name: Label PR
       # Runs only on pull_request events (needs a PR number) and only if the gate

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -137,6 +137,20 @@ runs:
         fi
         exit "$RC"
 
+    - name: Upload ABI report
+      # Uploaded on every run (success or fail) so a surprising verdict can be
+      # triaged symbol-by-symbol offline. abi_check.sh stages the abicc HTML
+      # reports, the two .dump files, and the removed-constants list under
+      # $GITHUB_WORKSPACE/abi-report/ before exiting the container. The
+      # step is a no-op when the container exited before that stage ran.
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: abi-report-${{ github.event.pull_request.number || github.run_id }}
+        path: ${{ github.workspace }}/abi-report
+        if-no-files-found: ignore
+        retention-days: 30
+
     - name: Label PR
       # Runs only on pull_request events (needs a PR number) and only if the gate
       # produced a verdict. Adds the applicable label (patch|minor|needs-review)

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'Explicit base ref to diff against (e.g. a previous release tag), overriding the PR base ref. Set this only from a non-PR caller (e.g. a release workflow comparing "previous tag vs current ref"); PR workflows must leave this empty so the PR base ref is used and the PR gets labeled.'
     required: false
     default: ''
+  header-subdir:
+    description: 'Subdirectory under <install>/include/aws/ that contains THIS library''s public headers. Scoping the ABI dump to just this dir prevents transitive dep headers (aws-c-common, aws-c-io, ...) that share the install tree from leaking into the diff. Defaults to lib-name with the leading "aws-c-" (or "aws-") prefix stripped; override when the header dir does not follow that convention (e.g. aws-c-iot installs under aws/iotdevice/).'
+    required: false
+    default: ''
 
 outputs:
   label:
@@ -91,6 +95,7 @@ runs:
         BUILDER_SOURCE: ${{ inputs.builder-source }}
         BUILDER_HOST: ${{ inputs.builder-host }}
         ABI_BASE_REF: ${{ inputs.base-ref }}
+        ABI_HEADER_SUBDIR: ${{ inputs.header-subdir }}
       run: |
         # Mount the checkout at the same path so GITHUB_WORKSPACE resolves inside
         # the container, and mount the step-summary file so report.py can append
@@ -121,6 +126,7 @@ runs:
           --env "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
           --env "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER:-}" \
           --env "ABI_LIB_NAME=${LIB_NAME}" \
+          --env "ABI_HEADER_SUBDIR=${ABI_HEADER_SUBDIR:-}" \
           --env "BUILDER_VERSION=${BUILDER_VERSION}" \
           --env "BUILDER_SOURCE=${BUILDER_SOURCE}" \
           --env "BUILDER_HOST=${BUILDER_HOST}" \

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -138,15 +138,6 @@ runs:
         exit "$RC"
 
     - name: Upload ABI artifacts
-      # Uploaded on every run (success or fail) so a surprising verdict can be
-      # triaged symbol-by-symbol offline. abi_check.sh stages the abicc HTML
-      # reports, the two .dump files, and the removed-constants list under
-      # $GITHUB_WORKSPACE/abi-artifacts/ before exiting the container. The step
-      # is a no-op when the container exited before that stage ran.
-      #
-      # Retention: 7 days. Triage almost always happens within a few days of
-      # a surprising run; a stale artifact isn't useful anyway (dep HEADs have
-      # moved). Re-run the check-abi workflow to regenerate if needed later.
       if: always()
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -117,6 +117,8 @@ runs:
           "${SUMMARY_MOUNT[@]}" \
           --env "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}" \
           --env "GITHUB_BASE_REF=${GITHUB_BASE_REF:-}" \
+          --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
+          --env "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" \
           --env "ABI_BASE_REF=${ABI_BASE_REF:-}" \
           --env "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
           --env "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER:-}" \

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -118,7 +118,6 @@ runs:
           --env "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}" \
           --env "GITHUB_BASE_REF=${GITHUB_BASE_REF:-}" \
           --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
-          --env "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" \
           --env "ABI_BASE_REF=${ABI_BASE_REF:-}" \
           --env "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
           --env "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER:-}" \

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -45,10 +45,6 @@ inputs:
     description: 'Explicit base ref to diff against (e.g. a previous release tag), overriding the PR base ref. Set this only from a non-PR caller (e.g. a release workflow comparing "previous tag vs current ref"); PR workflows must leave this empty so the PR base ref is used and the PR gets labeled.'
     required: false
     default: ''
-  header-subdir:
-    description: 'Subdirectory under <install>/include/aws/ that contains THIS library''s public headers. Scoping the ABI dump to just this dir prevents transitive dep headers (aws-c-common, aws-c-io, ...) that share the install tree from leaking into the diff. Defaults to lib-name with the leading "aws-c-" (or "aws-") prefix stripped; override when the header dir does not follow that convention (e.g. aws-c-iot installs under aws/iotdevice/).'
-    required: false
-    default: ''
 
 outputs:
   label:
@@ -95,7 +91,6 @@ runs:
         BUILDER_SOURCE: ${{ inputs.builder-source }}
         BUILDER_HOST: ${{ inputs.builder-host }}
         ABI_BASE_REF: ${{ inputs.base-ref }}
-        ABI_HEADER_SUBDIR: ${{ inputs.header-subdir }}
       run: |
         # Mount the checkout at the same path so GITHUB_WORKSPACE resolves inside
         # the container, and mount the step-summary file so report.py can append
@@ -126,7 +121,6 @@ runs:
           --env "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
           --env "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER:-}" \
           --env "ABI_LIB_NAME=${LIB_NAME}" \
-          --env "ABI_HEADER_SUBDIR=${ABI_HEADER_SUBDIR:-}" \
           --env "BUILDER_VERSION=${BUILDER_VERSION}" \
           --env "BUILDER_SOURCE=${BUILDER_SOURCE}" \
           --env "BUILDER_HOST=${BUILDER_HOST}" \

--- a/.github/actions/check-abi/scripts/abi_check.sh
+++ b/.github/actions/check-abi/scripts/abi_check.sh
@@ -100,3 +100,23 @@ run_stage compare.sh
 # Publish the summary and gate, mirroring action.yml's always() steps.
 python3 "${SCRIPT_DIR}/report.py" || true
 bash "${SCRIPT_DIR}/gate.sh"
+GATE_RC=$?
+
+# --- Stage the ABI reports where the host can upload them --------------------
+# ABI_OUT_DIR lives on the container's tmpfs and disappears with the container.
+# Copy it under $GITHUB_WORKSPACE (bind-mounted from the host) so a downstream
+# upload-artifact step can grab it. Include the ABI dumps and the constants
+# report so a per-symbol diff is inspectable long after the run has ended --
+# without an artifact upload path the log only tells you "97.7%", not which
+# symbol drove that percentage.
+if [[ -n "${ABI_OUT_DIR:-}" && -d "$ABI_OUT_DIR" && -n "${GITHUB_WORKSPACE:-}" ]]; then
+  STAGE_DIR="${GITHUB_WORKSPACE}/abi-report"
+  mkdir -p "$STAGE_DIR"
+  cp -a "$ABI_OUT_DIR"/. "$STAGE_DIR/" 2>/dev/null || true
+  if [[ -n "${ABI_REMOVED_CONSTANTS_FILE:-}" && -f "$ABI_REMOVED_CONSTANTS_FILE" ]]; then
+    cp -a "$ABI_REMOVED_CONSTANTS_FILE" "$STAGE_DIR/removed-constants.txt" 2>/dev/null || true
+  fi
+  echo "ABI reports staged for artifact upload at ${STAGE_DIR}"
+fi
+
+exit "$GATE_RC"

--- a/.github/actions/check-abi/scripts/abi_check.sh
+++ b/.github/actions/check-abi/scripts/abi_check.sh
@@ -102,13 +102,8 @@ python3 "${SCRIPT_DIR}/report.py" || true
 bash "${SCRIPT_DIR}/gate.sh"
 GATE_RC=$?
 
-# --- Stage the ABI artifacts where the host can upload them ------------------
-# ABI_OUT_DIR lives on the container's tmpfs and disappears with the container.
-# Copy it under $GITHUB_WORKSPACE (bind-mounted from the host) so a downstream
-# upload-artifact step can grab it. Include the abicc HTML reports, the two
-# .dump files, and the removed-constants list so a per-symbol diff is
-# inspectable long after the run has ended -- without this, the log only
-# tells you "97.7%", not which symbol drove that percentage.
+# --- Stage ABI artifacts for host-side upload --------------------------------
+# ABI_OUT_DIR is in-container tmpfs; copy to $GITHUB_WORKSPACE so upload-artifact can grab it.
 if [[ -n "${ABI_OUT_DIR:-}" && -d "$ABI_OUT_DIR" && -n "${GITHUB_WORKSPACE:-}" ]]; then
   STAGE_DIR="${GITHUB_WORKSPACE}/abi-artifacts"
   mkdir -p "$STAGE_DIR"

--- a/.github/actions/check-abi/scripts/abi_check.sh
+++ b/.github/actions/check-abi/scripts/abi_check.sh
@@ -102,21 +102,21 @@ python3 "${SCRIPT_DIR}/report.py" || true
 bash "${SCRIPT_DIR}/gate.sh"
 GATE_RC=$?
 
-# --- Stage the ABI reports where the host can upload them --------------------
+# --- Stage the ABI artifacts where the host can upload them ------------------
 # ABI_OUT_DIR lives on the container's tmpfs and disappears with the container.
 # Copy it under $GITHUB_WORKSPACE (bind-mounted from the host) so a downstream
-# upload-artifact step can grab it. Include the ABI dumps and the constants
-# report so a per-symbol diff is inspectable long after the run has ended --
-# without an artifact upload path the log only tells you "97.7%", not which
-# symbol drove that percentage.
+# upload-artifact step can grab it. Include the abicc HTML reports, the two
+# .dump files, and the removed-constants list so a per-symbol diff is
+# inspectable long after the run has ended -- without this, the log only
+# tells you "97.7%", not which symbol drove that percentage.
 if [[ -n "${ABI_OUT_DIR:-}" && -d "$ABI_OUT_DIR" && -n "${GITHUB_WORKSPACE:-}" ]]; then
-  STAGE_DIR="${GITHUB_WORKSPACE}/abi-report"
+  STAGE_DIR="${GITHUB_WORKSPACE}/abi-artifacts"
   mkdir -p "$STAGE_DIR"
   cp -a "$ABI_OUT_DIR"/. "$STAGE_DIR/" 2>/dev/null || true
   if [[ -n "${ABI_REMOVED_CONSTANTS_FILE:-}" && -f "$ABI_REMOVED_CONSTANTS_FILE" ]]; then
     cp -a "$ABI_REMOVED_CONSTANTS_FILE" "$STAGE_DIR/removed-constants.txt" 2>/dev/null || true
   fi
-  echo "ABI reports staged for artifact upload at ${STAGE_DIR}"
+  echo "ABI artifacts staged for upload at ${STAGE_DIR}"
 fi
 
 exit "$GATE_RC"

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -89,16 +89,8 @@ build_ref() {
   # dropped Source/SourceLine metadata, not the struct/type data
   # abi-compliance-checker compares. Forcing DWARF4 just silences the noise.
   #
-  # --branch main: builder infers the branch to clone for each transitive dep
-  # from the source project's current branch, falling back to the dep's default
-  # only if that name doesn't exist. So if THIS repo is on a feature branch
-  # (say "ci-cd") and the same-named branch happens to exist on a dep (say
-  # aws-c-io/ci-cd -- which does happen when the fleet coordinates a rollout),
-  # the HEAD build would silently link against the dep's feature branch while
-  # the BASE build (on origin/main) would link against the dep's main. The two
-  # sides then diff against DIFFERENT dep code, which surfaces as this
-  # library's ABI drift even when its own source is unchanged. Pinning both
-  # builds to main forces apples-to-apples across the dep graph.
+  # --branch main: ensure both sides clone the same dep branch regardless of
+  # the source project's current branch.
   ( cd "$src_dir" && python3 "$BUILDER_PYZ" build -p "$LIB_NAME" \
       --branch main \
       --cmake-extra=-DBUILD_SHARED_LIBS=ON \
@@ -121,13 +113,7 @@ rc_base=0; wait "$pid_base" || rc_base=$?
   echo "ABI_BASE_INSTALL=${BASE_INSTALL}"
 } >> "$GITHUB_ENV"
 
-# --- Log the exact upstream dep SHAs each build resolved ---------------------
-# builder pulls upstream libs (aws-c-common, aws-c-io, ...) from HEAD of their
-# default branch at run time, so the two builds don't necessarily see the same
-# commit -- a push landing between the two clones would silently split them.
-# Emit each dep's resolved SHA + describe here for both refs, both in the log
-# (grep-friendly) and in the job summary (side-by-side compare) so a surprising
-# ABI verdict can be triaged against dep drift instead of guessed at.
+# --- Log resolved dep SHAs ---------------------------------------------------
 log_dep_shas() {
   local label="$1" src_dir="$2"
   local deps_dir="${src_dir}/build/deps" dep dep_name sha describe
@@ -149,9 +135,6 @@ log_dep_shas "HEAD" "$HEAD_DIR"
 log_dep_shas "BASE (${BASE_REF})" "$BASE_WORKTREE"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  # Build a base<->head SHA table so mismatches jump out. Any dep whose SHA
-  # differs between the two builds is a candidate root cause for a surprising
-  # ABI verdict.
   head_deps_dir="${HEAD_DIR}/build/deps"
   base_deps_dir="${BASE_WORKTREE}/build/deps"
   {
@@ -161,7 +144,6 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "| Dep | Base SHA | Head SHA | Match |"
     echo "|-----|----------|----------|-------|"
     if [[ -d "$head_deps_dir" || -d "$base_deps_dir" ]]; then
-      # Union of dep names across both trees.
       { ls "$head_deps_dir" 2>/dev/null; ls "$base_deps_dir" 2>/dev/null; } | sort -u | while read -r dep_name; do
         [[ -z "$dep_name" ]] && continue
         base_sha="$(git -C "${base_deps_dir}/${dep_name}" rev-parse HEAD 2>/dev/null || echo 'missing')"

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -134,29 +134,6 @@ log_dep_shas() {
 log_dep_shas "HEAD" "$HEAD_DIR"
 log_dep_shas "BASE (${BASE_REF})" "$BASE_WORKTREE"
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  head_deps_dir="${HEAD_DIR}/build/deps"
-  base_deps_dir="${BASE_WORKTREE}/build/deps"
-  {
-    echo
-    echo "### Resolved dependency versions"
-    echo
-    echo "| Dep | Base SHA | Head SHA | Match |"
-    echo "|-----|----------|----------|-------|"
-    if [[ -d "$head_deps_dir" || -d "$base_deps_dir" ]]; then
-      { ls "$head_deps_dir" 2>/dev/null; ls "$base_deps_dir" 2>/dev/null; } | sort -u | while read -r dep_name; do
-        [[ -z "$dep_name" ]] && continue
-        base_sha="$(git -C "${base_deps_dir}/${dep_name}" rev-parse HEAD 2>/dev/null || echo 'missing')"
-        head_sha="$(git -C "${head_deps_dir}/${dep_name}" rev-parse HEAD 2>/dev/null || echo 'missing')"
-        if [[ "$base_sha" == "$head_sha" ]]; then match=":white_check_mark:"; else match=":warning:"; fi
-        printf '| %s | `%s` | `%s` | %s |\n' "$dep_name" "${base_sha:0:12}" "${head_sha:0:12}" "$match"
-      done
-    else
-      echo "| (no build/deps dirs found) | - | - | - |"
-    fi
-  } >> "$GITHUB_STEP_SUMMARY"
-fi
-
 if [[ "$rc_head" -ne 0 ]]; then
   echo "ERROR: HEAD build failed (exit $rc_head)" >&2
   exit 1

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -88,7 +88,19 @@ build_ref() {
   # logging a harmless "invalid debug_loc section" warning that only affects
   # dropped Source/SourceLine metadata, not the struct/type data
   # abi-compliance-checker compares. Forcing DWARF4 just silences the noise.
+  #
+  # --branch main: builder infers the branch to clone for each transitive dep
+  # from the source project's current branch, falling back to the dep's default
+  # only if that name doesn't exist. So if THIS repo is on a feature branch
+  # (say "ci-cd") and the same-named branch happens to exist on a dep (say
+  # aws-c-io/ci-cd -- which does happen when the fleet coordinates a rollout),
+  # the HEAD build would silently link against the dep's feature branch while
+  # the BASE build (on origin/main) would link against the dep's main. The two
+  # sides then diff against DIFFERENT dep code, which surfaces as this
+  # library's ABI drift even when its own source is unchanged. Pinning both
+  # builds to main forces apples-to-apples across the dep graph.
   ( cd "$src_dir" && python3 "$BUILDER_PYZ" build -p "$LIB_NAME" \
+      --branch main \
       --cmake-extra=-DBUILD_SHARED_LIBS=ON \
       --cmake-extra=-DBUILD_TESTING=OFF \
       --cmake-extra="-DCMAKE_C_FLAGS_RELWITHDEBINFO=-g -Og -gdwarf-4 -DNDEBUG" \

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -109,6 +109,60 @@ rc_base=0; wait "$pid_base" || rc_base=$?
   echo "ABI_BASE_INSTALL=${BASE_INSTALL}"
 } >> "$GITHUB_ENV"
 
+# --- Log the exact upstream dep SHAs each build resolved ---------------------
+# builder pulls upstream libs (aws-c-common, aws-c-io, ...) from HEAD of their
+# default branch at run time, so the two builds don't necessarily see the same
+# commit -- a push landing between the two clones would silently split them.
+# Emit each dep's resolved SHA + describe here for both refs, both in the log
+# (grep-friendly) and in the job summary (side-by-side compare) so a surprising
+# ABI verdict can be triaged against dep drift instead of guessed at.
+log_dep_shas() {
+  local label="$1" src_dir="$2"
+  local deps_dir="${src_dir}/build/deps" dep dep_name sha describe
+  echo "=== deps resolved for ${label} build (${src_dir}) ==="
+  if [[ ! -d "$deps_dir" ]]; then
+    echo "  (no build/deps dir found at ${deps_dir})"
+    return
+  fi
+  for dep in "$deps_dir"/*/; do
+    [[ -d "${dep}.git" ]] || continue
+    dep_name="$(basename "$dep")"
+    sha="$(git -C "$dep" rev-parse HEAD 2>/dev/null || echo '?')"
+    describe="$(git -C "$dep" describe --tags --always --long 2>/dev/null || echo '?')"
+    printf '  %-25s %s  (%s)\n' "$dep_name" "$sha" "$describe"
+  done
+}
+
+log_dep_shas "HEAD" "$HEAD_DIR"
+log_dep_shas "BASE (${BASE_REF})" "$BASE_WORKTREE"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  # Build a base<->head SHA table so mismatches jump out. Any dep whose SHA
+  # differs between the two builds is a candidate root cause for a surprising
+  # ABI verdict.
+  head_deps_dir="${HEAD_DIR}/build/deps"
+  base_deps_dir="${BASE_WORKTREE}/build/deps"
+  {
+    echo
+    echo "### Resolved dependency versions"
+    echo
+    echo "| Dep | Base SHA | Head SHA | Match |"
+    echo "|-----|----------|----------|-------|"
+    if [[ -d "$head_deps_dir" || -d "$base_deps_dir" ]]; then
+      # Union of dep names across both trees.
+      { ls "$head_deps_dir" 2>/dev/null; ls "$base_deps_dir" 2>/dev/null; } | sort -u | while read -r dep_name; do
+        [[ -z "$dep_name" ]] && continue
+        base_sha="$(git -C "${base_deps_dir}/${dep_name}" rev-parse HEAD 2>/dev/null || echo 'missing')"
+        head_sha="$(git -C "${head_deps_dir}/${dep_name}" rev-parse HEAD 2>/dev/null || echo 'missing')"
+        if [[ "$base_sha" == "$head_sha" ]]; then match=":white_check_mark:"; else match=":warning:"; fi
+        printf '| %s | `%s` | `%s` | %s |\n' "$dep_name" "${base_sha:0:12}" "${head_sha:0:12}" "$match"
+      done
+    else
+      echo "| (no build/deps dirs found) | - | - | - |"
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
 if [[ "$rc_head" -ne 0 ]]; then
   echo "ERROR: HEAD build failed (exit $rc_head)" >&2
   exit 1

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -89,15 +89,22 @@ build_ref() {
   # dropped Source/SourceLine metadata, not the struct/type data
   # abi-compliance-checker compares. Forcing DWARF4 just silences the noise.
   #
-  # --branch main: ensure both sides clone the same dep branch regardless of
-  # the source project's current branch.
+  # Pass an explicit --branch so both builds resolve deps identically.
   ( cd "$src_dir" && python3 "$BUILDER_PYZ" build -p "$LIB_NAME" \
-      --branch main \
+      --branch "$DEP_BRANCH" \
       --cmake-extra=-DBUILD_SHARED_LIBS=ON \
       --cmake-extra=-DBUILD_TESTING=OFF \
       --cmake-extra="-DCMAKE_C_FLAGS_RELWITHDEBINFO=-g -Og -gdwarf-4 -DNDEBUG" \
       run_tests=false )
 }
+
+# On a PR event GITHUB_HEAD_REF is the PR's source branch (e.g. "ci-cd") --
+# use it so both builds honor the same coordinated feature branch on deps
+# (builder falls back to the dep's default if the branch doesn't exist).
+# Off a PR (workflow_dispatch, push), fall back to main.
+DEP_BRANCH="${GITHUB_HEAD_REF:-main}"
+[[ -z "$DEP_BRANCH" ]] && DEP_BRANCH=main
+echo "Dep branch for both builds: ${DEP_BRANCH}"
 
 echo "Building HEAD ($HEAD_DIR) and base ($BASE_WORKTREE) in parallel"
 build_ref "$HEAD_DIR" &

--- a/.github/actions/check-abi/scripts/dump.sh
+++ b/.github/actions/check-abi/scripts/dump.sh
@@ -2,13 +2,22 @@
 #
 # dump.sh - Locate the built shared library for each ref and dump its ABI.
 #
-# cmake installs only public headers to the install tree, so we point
-# abi-dumper at <install>/include to scope the dump to the public API.
+# The install tree at <install>/include/aws/ is a UNION of every library in
+# the dep graph: aws-c-common/, aws-c-io/, aws-c-cal/, ... and finally the
+# target library's own headers. Pointing abi-dumper at <install>/include
+# would silently pull transitive dep types into this library's ABI dump, so
+# an aws-c-io struct change would surface as this library's ABI drift.
+# Scope -public-headers to just <install>/include/aws/<subdir>/ instead --
+# subdir derived from LIB_NAME (aws-c-X -> X, aws-X -> X), overridable via
+# ABI_HEADER_SUBDIR for outliers (aws-c-iot installs under aws/iotdevice/).
 #
 # Inputs (env):
-#   ABI_LIB_NAME      library name -> lib<name>.so
-#   ABI_HEAD_INSTALL  install prefix of the head build
-#   ABI_BASE_INSTALL  install prefix of the base build
+#   ABI_LIB_NAME       library name -> lib<name>.so
+#   ABI_HEAD_INSTALL   install prefix of the head build
+#   ABI_BASE_INSTALL   install prefix of the base build
+#   ABI_HEADER_SUBDIR  optional: subdir under include/aws/ containing this
+#                       library's public headers. Defaults to LIB_NAME with
+#                       the leading "aws-c-" (else "aws-") prefix stripped.
 #
 # Outputs (appended to $GITHUB_ENV):
 #   ABI_OUT_DIR    report/work directory
@@ -30,16 +39,28 @@ HEAD_SO="$(find_so "$HEAD_INSTALL")"
 [[ -n "$BASE_SO" ]] || { echo "ERROR: lib${LIB_NAME}.so not found under $BASE_INSTALL" >&2; exit 1; }
 [[ -n "$HEAD_SO" ]] || { echo "ERROR: lib${LIB_NAME}.so not found under $HEAD_INSTALL" >&2; exit 1; }
 
+# Derive the header subdir from the library name unless the caller overrode it.
+SUBDIR="${ABI_HEADER_SUBDIR:-}"
+if [[ -z "$SUBDIR" ]]; then
+  SUBDIR="${LIB_NAME#aws-c-}"
+  [[ "$SUBDIR" == "$LIB_NAME" ]] && SUBDIR="${LIB_NAME#aws-}"
+fi
+
+BASE_HEADERS="${BASE_INSTALL}/include/aws/${SUBDIR}"
+HEAD_HEADERS="${HEAD_INSTALL}/include/aws/${SUBDIR}"
+[[ -d "$BASE_HEADERS" ]] || { echo "ERROR: public headers not found at $BASE_HEADERS. Override with the check-abi action's 'header-subdir' input." >&2; exit 1; }
+[[ -d "$HEAD_HEADERS" ]] || { echo "ERROR: public headers not found at $HEAD_HEADERS. Override with the check-abi action's 'header-subdir' input." >&2; exit 1; }
+
 OUT_DIR="$(mktemp -d)" || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
 BASE_DUMP="${OUT_DIR}/base.dump"
 HEAD_DUMP="${OUT_DIR}/head.dump"
 
-echo "Dumping ABI for base ($BASE_SO) and head ($HEAD_SO) in parallel"
+echo "Dumping ABI for base ($BASE_SO) and head ($HEAD_SO); headers scoped to aws/${SUBDIR}/"
 abi-dumper "$BASE_SO" -o "$BASE_DUMP" -lver base \
-  -public-headers "${BASE_INSTALL}/include" &
+  -public-headers "$BASE_HEADERS" &
 pid_base=$!
 abi-dumper "$HEAD_SO" -o "$HEAD_DUMP" -lver head \
-  -public-headers "${HEAD_INSTALL}/include" &
+  -public-headers "$HEAD_HEADERS" &
 pid_head=$!
 
 rc_base=0; wait "$pid_base" || rc_base=$?

--- a/.github/actions/check-abi/scripts/dump.sh
+++ b/.github/actions/check-abi/scripts/dump.sh
@@ -2,22 +2,13 @@
 #
 # dump.sh - Locate the built shared library for each ref and dump its ABI.
 #
-# The install tree at <install>/include/aws/ is a UNION of every library in
-# the dep graph: aws-c-common/, aws-c-io/, aws-c-cal/, ... and finally the
-# target library's own headers. Pointing abi-dumper at <install>/include
-# would silently pull transitive dep types into this library's ABI dump, so
-# an aws-c-io struct change would surface as this library's ABI drift.
-# Scope -public-headers to just <install>/include/aws/<subdir>/ instead --
-# subdir derived from LIB_NAME (aws-c-X -> X, aws-X -> X), overridable via
-# ABI_HEADER_SUBDIR for outliers (aws-c-iot installs under aws/iotdevice/).
+# cmake installs only public headers to the install tree, so we point
+# abi-dumper at <install>/include to scope the dump to the public API.
 #
 # Inputs (env):
-#   ABI_LIB_NAME       library name -> lib<name>.so
-#   ABI_HEAD_INSTALL   install prefix of the head build
-#   ABI_BASE_INSTALL   install prefix of the base build
-#   ABI_HEADER_SUBDIR  optional: subdir under include/aws/ containing this
-#                       library's public headers. Defaults to LIB_NAME with
-#                       the leading "aws-c-" (else "aws-") prefix stripped.
+#   ABI_LIB_NAME      library name -> lib<name>.so
+#   ABI_HEAD_INSTALL  install prefix of the head build
+#   ABI_BASE_INSTALL  install prefix of the base build
 #
 # Outputs (appended to $GITHUB_ENV):
 #   ABI_OUT_DIR    report/work directory
@@ -39,28 +30,16 @@ HEAD_SO="$(find_so "$HEAD_INSTALL")"
 [[ -n "$BASE_SO" ]] || { echo "ERROR: lib${LIB_NAME}.so not found under $BASE_INSTALL" >&2; exit 1; }
 [[ -n "$HEAD_SO" ]] || { echo "ERROR: lib${LIB_NAME}.so not found under $HEAD_INSTALL" >&2; exit 1; }
 
-# Derive the header subdir from the library name unless the caller overrode it.
-SUBDIR="${ABI_HEADER_SUBDIR:-}"
-if [[ -z "$SUBDIR" ]]; then
-  SUBDIR="${LIB_NAME#aws-c-}"
-  [[ "$SUBDIR" == "$LIB_NAME" ]] && SUBDIR="${LIB_NAME#aws-}"
-fi
-
-BASE_HEADERS="${BASE_INSTALL}/include/aws/${SUBDIR}"
-HEAD_HEADERS="${HEAD_INSTALL}/include/aws/${SUBDIR}"
-[[ -d "$BASE_HEADERS" ]] || { echo "ERROR: public headers not found at $BASE_HEADERS. Override with the check-abi action's 'header-subdir' input." >&2; exit 1; }
-[[ -d "$HEAD_HEADERS" ]] || { echo "ERROR: public headers not found at $HEAD_HEADERS. Override with the check-abi action's 'header-subdir' input." >&2; exit 1; }
-
 OUT_DIR="$(mktemp -d)" || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
 BASE_DUMP="${OUT_DIR}/base.dump"
 HEAD_DUMP="${OUT_DIR}/head.dump"
 
-echo "Dumping ABI for base ($BASE_SO) and head ($HEAD_SO); headers scoped to aws/${SUBDIR}/"
+echo "Dumping ABI for base ($BASE_SO) and head ($HEAD_SO) in parallel"
 abi-dumper "$BASE_SO" -o "$BASE_DUMP" -lver base \
-  -public-headers "$BASE_HEADERS" &
+  -public-headers "${BASE_INSTALL}/include" &
 pid_base=$!
 abi-dumper "$HEAD_SO" -o "$HEAD_DUMP" -lver head \
-  -public-headers "$HEAD_HEADERS" &
+  -public-headers "${HEAD_INSTALL}/include" &
 pid_head=$!
 
 rc_base=0; wait "$pid_base" || rc_base=$?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Improve commit message on auto-releases.
- Add option to upload artifacts of the check-abi action.
- Log the sha commit ids of dependencies for easier debugging.
- force both versions to use the same branch (either feature branch if exists, or main)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.