### PR TITLE
Update branch finding logic

### DIFF
--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -156,7 +156,6 @@ class Env(object):
             branches_unfiltered = [branch.strip() for branch in branch_output.splitlines()]
             print("Found branches:", branches_unfiltered)
 
-            branches = []
             star_branch = None
             for line in branches_unfiltered:
                 branch = line.lstrip('*').strip()
@@ -165,24 +164,23 @@ class Env(object):
                 if branch.startswith('('):
                     continue
 
+                # only the '*' entry tells us the branch we're actually on
                 if line.startswith('*'):
                     star_branch = branch
-
-                branches.append(branch)
+                    break
 
             # if git branch says we're on a branch, that's it
             if star_branch:
                 print('Working in branch: {}'.format(star_branch))
                 return star_branch
 
-            # pick the first one (it should be the only one, if it's a fresh sync)
-            for branch in branches:
-                origin_str = "remotes/origin/"
-                if branch.startswith(origin_str):
-                    branch = branch[len(origin_str):]
-
-                print('Working in branch: {}'.format(branch))
-                return branch
+            # Detached HEAD (a git worktree, a tag/sha checkout, or a CI merge
+            # ref): the commit can be contained by many branches and there is no
+            # reliable way to know which one we're "on". Do NOT guess by taking
+            # the first entry from `git branch --contains` -- an arbitrary pick
+            # silently drives cross-repo branch matching to the wrong dependency
+            # branch. Default to main instead of guessing.
+            print("Detached HEAD; can't determine branch reliably, defaulting to main")
         except:
             print("Current directory ({}) is not a git repository".format(os.getcwd()))
 

--- a/builder/core/env.py
+++ b/builder/core/env.py
@@ -164,10 +164,10 @@ class Env(object):
                 if branch.startswith('('):
                     continue
 
-                # only the '*' entry tells us the branch we're actually on
+                # only the '*' entry tells us the branch we're actually on;
+                # scan the whole list since the starred line may not be first
                 if line.startswith('*'):
                     star_branch = branch
-                    break
 
             # if git branch says we're on a branch, that's it
             if star_branch:


### PR DESCRIPTION
*Issue #, if available:*

`Env._get_git_branch()` falls back to `git branch -a --contains HEAD` when no CI branch env vars are set, then, if there is no `*` (active) branch, **picks the first branch in the list**. `git branch --contains` returns *every branch whose history includes the current commit* — not the branch you are on. On a **detached HEAD** sitting on a shared ancestor commit (e.g. the `main` tip), that set contains many branches, and "pick the first" returns the alphabetically-first one — an arbitrary, silently-wrong guess.

This branch name then drives cross-repo dependency branch matching (`DownloadDependencies` in `builder/actions/git.py`), so builder can end up checking out the wrong branch of a dependency.

_Observed impact_

In `aws-c-event-stream`'s `check-abi` job, the base build runs from a detached-HEAD `git worktree` at the `main` tip. `_get_git_branch()` returned `ai/readme-macos-crypto-deps` (alphabetically first among the branches containing that commit) instead of `main`. That branch happens to exist in `aws-c-io`, so the base build compiled `aws-c-io@ai/readme-macos-crypto-deps` while the head build used `aws-c-io@main`. The two `aws_socket_options` layouts differed (40 vs 44 bytes), producing a phantom binary-incompatible `minor` verdict on a PR that changed no C source.

*Description of changes:*

Only trust the branch git explicitly reports us as on (the `*` entry). If HEAD is detached and there is no `*` branch, **do not guess** — fall through to the existing `return 'main'`.

- Normal local checkouts (on a real branch) are unchanged: the `*` branch is still returned.
- CI env-var paths (`GITHUB_HEAD_REF`, `GITHUB_REF`, Travis) are unchanged.
- Only the ambiguous detached-HEAD case changes: `main` instead of an arbitrary pick.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.