### PR TITLE
Changes to ABI workflow

### DIFF
--- a/.github/actions/check-abi/README.md
+++ b/.github/actions/check-abi/README.md
@@ -69,12 +69,11 @@ The consumer workflow must, before invoking this action:
   action targets today (none use submodules for their public API surface), but
   it means this action is **not** a drop-in fit for a repo like `aws-crt-cpp`
   that does use them, without further work.
-- **Default branch must be reachable as `origin/main`.** When triggered outside
-  a `pull_request` event (and `base-ref` isn't set), the base ref is resolved
-  via `git merge-base HEAD origin/main`. A consumer repo whose default branch
-  isn't literally named `main` will hit a clear, actionable error (see
-  `scripts/build.sh`) rather than a silent misdetection, but this is a real
-  portability gap worth knowing about up front.
+- **Default branch must be fetchable.** When triggered outside a
+  `pull_request` event (and `base-ref` isn't set), the base ref is resolved via
+  `git merge-base HEAD origin/<default-branch>`, taking the branch name from the
+  event payload and falling back to `main`. Check out with `fetch-depth: 0` so
+  it is reachable.
 - **Single-library scope.** Each run diffs one library's own ABI/API against
   its own previous version. It cannot detect a break that only manifests when
   a *different* library in the dependency graph is upgraded without a

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -110,8 +110,9 @@ runs:
 
         # tee streams the log live and captures it in OUT for parsing below.
         # PIPESTATUS[0] is docker's exit code, not tee's.
-        set -o pipefail
         OUT="$(mktemp)"
+        # -e would abort here before RC is read, so guard the pipeline.
+        set +e
         docker run --rm \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
           -v "${GITHUB_ACTION_PATH}:/opt/check-abi:ro" \
@@ -132,13 +133,15 @@ runs:
           "${ABI_DOCKER_IMAGE}" \
           /opt/check-abi/scripts/abi_check.sh | tee "$OUT"
         RC="${PIPESTATUS[0]}"
+        set -e
 
-        LABEL="$(grep -o 'ABI_LABEL_RESULT::[a-zA-Z0-9_-]*' "$OUT" | tail -n1 | cut -d: -f3)"
+        # grep exits 1 when there is no verdict, which -e would treat as fatal.
+        LABEL="$(grep -o 'ABI_LABEL_RESULT::[a-zA-Z0-9_-]*' "$OUT" | tail -n1 | cut -d: -f3 || true)"
         rm -f "$OUT"
         if [[ -n "$LABEL" ]]; then
           echo "label=${LABEL}" >> "$GITHUB_OUTPUT"
         fi
-        exit "$RC"
+        echo "rc=${RC}" >> "$GITHUB_OUTPUT"
 
     - name: Upload ABI artifacts
       if: always()
@@ -215,3 +218,10 @@ runs:
           [[ "$other" == "$LABEL" ]] && continue
           gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$other" 2>/dev/null || true
         done
+
+    - name: Fail if the ABI check failed
+      if: ${{ steps.run_check.outputs.rc != '0' }}
+      shell: bash
+      run: |
+        echo "::error::ABI check exited ${{ steps.run_check.outputs.rc }}."
+        exit 1

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -91,6 +91,7 @@ runs:
         BUILDER_SOURCE: ${{ inputs.builder-source }}
         BUILDER_HOST: ${{ inputs.builder-host }}
         ABI_BASE_REF: ${{ inputs.base-ref }}
+        ABI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         # Mount the checkout at the same path so GITHUB_WORKSPACE resolves inside
         # the container, and mount the step-summary file so report.py can append
@@ -119,6 +120,7 @@ runs:
           --env "GITHUB_BASE_REF=${GITHUB_BASE_REF:-}" \
           --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
           --env "ABI_BASE_REF=${ABI_BASE_REF:-}" \
+          --env "ABI_DEFAULT_BRANCH=${ABI_DEFAULT_BRANCH:-}" \
           --env "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
           --env "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER:-}" \
           --env "ABI_LIB_NAME=${LIB_NAME}" \

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -155,12 +155,15 @@ runs:
       #
       # The PR number comes from the event on pull_request, and from a branch
       # lookup otherwise -- push-triggered runs carry no pull_request object.
+      # The lookup is pinned to the default branch: only merges there need a
+      # label, and a branch may have other open PRs against other bases.
       if: ${{ inputs.base-ref == '' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         PR_FROM_EVENT: ${{ github.event.pull_request.number }}
         BRANCH: ${{ github.head_ref || github.ref_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         REPO: ${{ github.repository }}
         PATCH_LABEL: ${{ inputs.patch-label }}
         MINOR_LABEL: ${{ inputs.minor-label }}
@@ -174,10 +177,10 @@ runs:
         PR_NUMBER="${PR_FROM_EVENT:-}"
         if [[ -z "$PR_NUMBER" ]]; then
           PR_NUMBER="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" \
-              --json number --jq '.[0].number // empty')"
+              --base "$DEFAULT_BRANCH" --json number --jq '.[0].number // empty')"
         fi
         if [[ -z "$PR_NUMBER" ]]; then
-          echo "No open PR for branch '${BRANCH}'; skipping labeling."
+          echo "No open PR from '${BRANCH}' into '${DEFAULT_BRANCH}'; skipping labeling."
           exit 0
         fi
         # Translate gate.sh's fixed verdict token ("patch"/"minor"/"needs-review")

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -148,16 +148,19 @@ runs:
         retention-days: 7
 
     - name: Label PR
-      # Runs only on pull_request events (needs a PR number) and only if the gate
-      # produced a verdict. Adds the applicable label (patch|minor|needs-review)
-      # and removes the other two so a re-run flips the label cleanly. Requires
+      # Adds the applicable label (patch|minor|needs-review) and removes the
+      # other two so a re-run flips the label cleanly. Requires
       # pull-requests: write; on fork PRs the token is read-only and this is a
       # no-op (labels are then informational via the job summary only).
-      if: ${{ github.event_name == 'pull_request' && inputs.base-ref == '' }}
+      #
+      # The PR number comes from the event on pull_request, and from a branch
+      # lookup otherwise -- push-triggered runs carry no pull_request object.
+      if: ${{ inputs.base-ref == '' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+        BRANCH: ${{ github.head_ref || github.ref_name }}
         REPO: ${{ github.repository }}
         PATCH_LABEL: ${{ inputs.patch-label }}
         MINOR_LABEL: ${{ inputs.minor-label }}
@@ -166,6 +169,15 @@ runs:
       run: |
         if [[ -z "${LABEL:-}" ]]; then
           echo "No ABI verdict was produced; skipping labeling."
+          exit 0
+        fi
+        PR_NUMBER="${PR_FROM_EVENT:-}"
+        if [[ -z "$PR_NUMBER" ]]; then
+          PR_NUMBER="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" \
+              --json number --jq '.[0].number // empty')"
+        fi
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "No open PR for branch '${BRANCH}'; skipping labeling."
           exit 0
         fi
         # Translate gate.sh's fixed verdict token ("patch"/"minor"/"needs-review")

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -167,11 +167,8 @@ runs:
         MINOR_LABEL: ${{ inputs.minor-label }}
         NEEDS_REVIEW_LABEL: ${{ inputs.needs-review-label }}
         LABEL: ${{ steps.run_check.outputs.label }}
+        RUN_RC: ${{ steps.run_check.outputs.rc }}
       run: |
-        if [[ -z "${LABEL:-}" ]]; then
-          echo "No ABI verdict was produced; skipping labeling."
-          exit 0
-        fi
         PR_NUMBER="${PR_FROM_EVENT:-}"
         if [[ -z "$PR_NUMBER" ]]; then
           # Push runs carry no pull_request object; find the PR whose head is
@@ -193,9 +190,17 @@ runs:
           fi
           PR_NUMBER="$MATCHES"
         fi
+        # Clear all three, then add at most one back.
+        ALL_LABELS=("$PATCH_LABEL" "$MINOR_LABEL" "$NEEDS_REVIEW_LABEL")
+        for l in "${ALL_LABELS[@]}"; do
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$l" 2>/dev/null || true
+        done
+        if [[ "${RUN_RC:-1}" != "0" || -z "${LABEL:-}" ]]; then
+          echo "No ABI verdict (rc=${RUN_RC:-?}); cleared verdict labels on #${PR_NUMBER}."
+          exit 0
+        fi
         # Translate gate.sh's fixed verdict token ("patch"/"minor"/"needs-review")
         # to the configured label name, since gate.sh has no access to these inputs.
-        ALL_LABELS=("$PATCH_LABEL" "$MINOR_LABEL" "$NEEDS_REVIEW_LABEL")
         case "$LABEL" in
           patch) LABEL="$PATCH_LABEL" ;;
           minor) LABEL="$MINOR_LABEL" ;;
@@ -218,11 +223,6 @@ runs:
           --description "ABI check: source/API compatibility broken, needs manual review" --force 2>/dev/null || true
         gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL" \
           || echo "WARNING: could not add label '$LABEL' (token may be read-only on fork PRs)."
-        # Remove the other two labels if present; ignore failure when absent.
-        for other in "${ALL_LABELS[@]}"; do
-          [[ "$other" == "$LABEL" ]] && continue
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$other" 2>/dev/null || true
-        done
 
     - name: Fail if the ABI check failed
       if: ${{ steps.run_check.outputs.rc != '0' }}

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -202,6 +202,12 @@ runs:
             *) echo "Unexpected ABI verdict token '$LABEL'; treating as no verdict." ;;
           esac
         fi
+        # A successful run with no parsable verdict is left alone; a failed run
+        # clears any stale verdict, since this commit's result is unknown.
+        if [[ "${RUN_RC:-1}" == "0" && -z "$TARGET" ]]; then
+          echo "No verdict parsed; leaving labels on #${PR_NUMBER} unchanged."
+          exit 0
+        fi
 
         CURRENT="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels -q '.labels[].name')"
         DROP=()
@@ -210,9 +216,7 @@ runs:
           grep -qxF "$l" <<< "$CURRENT" && DROP+=("$l")
         done
         ADD=""
-        if [[ -n "$TARGET" ]] && ! grep -qxF "$TARGET" <<< "$CURRENT"; then
-          ADD="$TARGET"
-        fi
+        [[ -n "$TARGET" ]] && { grep -qxF "$TARGET" <<< "$CURRENT" || ADD="$TARGET"; }
 
         if [[ -z "$ADD" && "${#DROP[@]}" -eq 0 ]]; then
           echo "Labels on #${PR_NUMBER} already correct (${TARGET:-none}); nothing to do."

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -153,21 +153,14 @@ runs:
         retention-days: 7
 
     - name: Label PR
-      # Adds the applicable label (patch|minor|needs-review) and removes the
-      # other two so a re-run flips the label cleanly. Requires
-      # pull-requests: write; on fork PRs the token is read-only and this is a
-      # no-op (labels are then informational via the job summary only).
-      #
-      # The PR number comes from the event on pull_request, and from a branch
-      # lookup otherwise -- push-triggered runs carry no pull_request object.
-      # The lookup is pinned to the default branch: only merges there need a
-      # label, and a branch may have other open PRs against other bases.
+      # Clears the three verdict labels, then applies the current one.
+      # Requires pull-requests: write.
       if: ${{ inputs.base-ref == '' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         PR_FROM_EVENT: ${{ github.event.pull_request.number }}
-        BRANCH: ${{ github.head_ref || github.ref_name }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         REPO: ${{ github.repository }}
         PATCH_LABEL: ${{ inputs.patch-label }}
@@ -181,12 +174,24 @@ runs:
         fi
         PR_NUMBER="${PR_FROM_EVENT:-}"
         if [[ -z "$PR_NUMBER" ]]; then
-          PR_NUMBER="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" \
-              --base "$DEFAULT_BRANCH" --json number --jq '.[0].number // empty')"
-        fi
-        if [[ -z "$PR_NUMBER" ]]; then
-          echo "No open PR from '${BRANCH}' into '${DEFAULT_BRANCH}'; skipping labeling."
-          exit 0
+          # Push runs carry no pull_request object; find the PR whose head is
+          # this commit. --search matches the SHA server-side; the jq filter
+          # then requires it to be the head, not just present in the PR.
+          MATCHES="$(gh pr list --repo "$REPO" --state open --search "$HEAD_SHA" --limit 2 \
+              --json number,headRefOid,baseRefName \
+              | jq -r --arg sha "$HEAD_SHA" --arg base "${DEFAULT_BRANCH:-main}" \
+                  '[.[] | select(.headRefOid == $sha and .baseRefName == $base)]
+                   | map(.number) | join(" ")')"
+          COUNT="$(wc -w <<< "$MATCHES")"
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No open PR into '${DEFAULT_BRANCH}' with head ${HEAD_SHA}; skipping labeling."
+            exit 0
+          fi
+          if [[ "$COUNT" -gt 1 ]]; then
+            echo "PRs ${MATCHES} all have head ${HEAD_SHA}; ambiguous, skipping labeling."
+            exit 0
+          fi
+          PR_NUMBER="$MATCHES"
         fi
         # Translate gate.sh's fixed verdict token ("patch"/"minor"/"needs-review")
         # to the configured label name, since gate.sh has no access to these inputs.

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -190,39 +190,52 @@ runs:
           fi
           PR_NUMBER="$MATCHES"
         fi
-        # Clear all three, then add at most one back.
         ALL_LABELS=("$PATCH_LABEL" "$MINOR_LABEL" "$NEEDS_REVIEW_LABEL")
-        for l in "${ALL_LABELS[@]}"; do
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$l" 2>/dev/null || true
-        done
-        if [[ "${RUN_RC:-1}" != "0" || -z "${LABEL:-}" ]]; then
-          echo "No ABI verdict (rc=${RUN_RC:-?}); cleared verdict labels on #${PR_NUMBER}."
-          exit 0
-        fi
         # Translate gate.sh's fixed verdict token ("patch"/"minor"/"needs-review")
         # to the configured label name, since gate.sh has no access to these inputs.
-        case "$LABEL" in
-          patch) LABEL="$PATCH_LABEL" ;;
-          minor) LABEL="$MINOR_LABEL" ;;
-          needs-review) LABEL="$NEEDS_REVIEW_LABEL" ;;
-          *) echo "Unexpected ABI verdict token '$LABEL'; skipping."; exit 0 ;;
-        esac
-        echo "Applying label '$LABEL' on PR #${PR_NUMBER}"
-        # gh pr edit --add-label fails if the label does not exist in the repo
-        # (it will not create it), so ensure all three labels exist first.
-        # --force makes create idempotent; ignore the failure when it exists.
-        gh label create "$PATCH_LABEL" --repo "$REPO" --color 0e8a16 \
-          --description "ABI backward-compatible (patch release)" --force 2>/dev/null || true
-        gh label create "$MINOR_LABEL" --repo "$REPO" --color fbca04 \
-          --description "ABI changed, source-compatible (minor release)" --force 2>/dev/null || true
-        # Bright red: source/API compatibility is broken -- callers fail to
-        # recompile. This is deliberately the most visually alarming of the
-        # three; a reviewer must look before deciding whether a minor bump
-        # (or a revert) is the right call.
-        gh label create "$NEEDS_REVIEW_LABEL" --repo "$REPO" --color d93f0b \
-          --description "ABI check: source/API compatibility broken, needs manual review" --force 2>/dev/null || true
-        gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL" \
-          || echo "WARNING: could not add label '$LABEL' (token may be read-only on fork PRs)."
+        TARGET=""
+        if [[ "${RUN_RC:-1}" == "0" && -n "${LABEL:-}" ]]; then
+          case "$LABEL" in
+            patch) TARGET="$PATCH_LABEL" ;;
+            minor) TARGET="$MINOR_LABEL" ;;
+            needs-review) TARGET="$NEEDS_REVIEW_LABEL" ;;
+            *) echo "Unexpected ABI verdict token '$LABEL'; treating as no verdict." ;;
+          esac
+        fi
+
+        CURRENT="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels -q '.labels[].name')"
+        DROP=()
+        for l in "${ALL_LABELS[@]}"; do
+          [[ "$l" == "$TARGET" ]] && continue
+          grep -qxF "$l" <<< "$CURRENT" && DROP+=("$l")
+        done
+        ADD=""
+        if [[ -n "$TARGET" ]] && ! grep -qxF "$TARGET" <<< "$CURRENT"; then
+          ADD="$TARGET"
+        fi
+
+        if [[ -z "$ADD" && "${#DROP[@]}" -eq 0 ]]; then
+          echo "Labels on #${PR_NUMBER} already correct (${TARGET:-none}); nothing to do."
+          exit 0
+        fi
+
+        EDIT=()
+        if [[ -n "$ADD" ]]; then
+          # gh pr edit --add-label fails if the label does not exist in the repo.
+          case "$ADD" in
+            "$PATCH_LABEL") COLOR=0e8a16; DESC="ABI backward-compatible (patch release)" ;;
+            "$MINOR_LABEL") COLOR=fbca04; DESC="ABI changed, source-compatible (minor release)" ;;
+            *)              COLOR=d93f0b; DESC="ABI check: source/API compatibility broken, needs manual review" ;;
+          esac
+          gh label create "$ADD" --repo "$REPO" --color "$COLOR" --description "$DESC" --force 2>/dev/null || true
+          EDIT+=(--add-label "$ADD")
+        fi
+        if [[ "${#DROP[@]}" -gt 0 ]]; then
+          EDIT+=(--remove-label "$(IFS=,; echo "${DROP[*]}")")
+        fi
+        echo "Updating #${PR_NUMBER}: add='${ADD:-none}' remove='${DROP[*]:-none}'"
+        gh pr edit "$PR_NUMBER" --repo "$REPO" "${EDIT[@]}" \
+          || echo "WARNING: could not update labels (token may be read-only on fork PRs)."
 
     - name: Fail if the ABI check failed
       if: ${{ steps.run_check.outputs.rc != '0' }}

--- a/.github/actions/check-abi/action.yml
+++ b/.github/actions/check-abi/action.yml
@@ -172,9 +172,9 @@ runs:
         PR_NUMBER="${PR_FROM_EVENT:-}"
         if [[ -z "$PR_NUMBER" ]]; then
           # Push runs carry no pull_request object; find the PR whose head is
-          # this commit. --search matches the SHA server-side; the jq filter
-          # then requires it to be the head, not just present in the PR.
-          MATCHES="$(gh pr list --repo "$REPO" --state open --search "$HEAD_SHA" --limit 2 \
+          # this commit. --search matches any PR containing the commit, so the
+          # jq filter narrows to the one where it is the head.
+          MATCHES="$(gh pr list --repo "$REPO" --state open --search "$HEAD_SHA" --limit 10 \
               --json number,headRefOid,baseRefName \
               | jq -r --arg sha "$HEAD_SHA" --arg base "${DEFAULT_BRANCH:-main}" \
                   '[.[] | select(.headRefOid == $sha and .baseRefName == $base)]

--- a/.github/actions/check-abi/scripts/build.sh
+++ b/.github/actions/check-abi/scripts/build.sh
@@ -11,6 +11,8 @@
 #   ABI_BUILDER_PYZ   absolute path to the downloaded builder.pyz
 #   GITHUB_WORKSPACE  the PR head checkout (set by GitHub Actions)
 #   GITHUB_BASE_REF   target branch name on pull_request events (may be empty)
+#   ABI_DEFAULT_BRANCH  repo default branch, used for the merge-base fallback
+#                      on push events. Defaults to 'main' when unset.
 #   ABI_BASE_REF      explicit base ref override (e.g. a previous release tag).
 #                      Takes precedence over GITHUB_BASE_REF/merge-base. Set by
 #                      the release workflow to diff "previous tag vs current
@@ -34,12 +36,13 @@ if [[ -n "${ABI_BASE_REF:-}" ]]; then
 elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
   BASE_REF="origin/${GITHUB_BASE_REF}"
 else
-  BASE_REF="$(git -C "$HEAD_DIR" merge-base HEAD origin/main 2>/dev/null)"
+  DEFAULT_BRANCH="${ABI_DEFAULT_BRANCH:-main}"
+  BASE_REF="$(git -C "$HEAD_DIR" merge-base HEAD "origin/${DEFAULT_BRANCH}" 2>/dev/null)"
   if [[ -z "$BASE_REF" ]]; then
     echo "ERROR: cannot determine ABI base ref. GITHUB_BASE_REF is unset and" >&2
-    echo "       'git merge-base HEAD origin/main' failed. Trigger via a" >&2
-    echo "       pull_request event, or ensure the default branch is named" >&2
-    echo "       'main' and is fetchable (checkout with fetch-depth: 0)." >&2
+    echo "       'git merge-base HEAD origin/${DEFAULT_BRANCH}' failed. Trigger via a" >&2
+    echo "       pull_request event, or ensure 'origin/${DEFAULT_BRANCH}' is" >&2
+    echo "       fetchable (checkout with fetch-depth: 0)." >&2
     exit 1
   fi
 fi

--- a/.github/workflows/block-needs-review-label.yml
+++ b/.github/workflows/block-needs-review-label.yml
@@ -7,12 +7,12 @@ jobs:
   gate:
     runs-on: ubuntu-24.04
     steps:
-      - name: Fail if needs-review is present
-        # Hardcoded, not an input: this must always match check-abi's own
-        # needs-review-label default. Making it configurable would let a
-        # caller override the label here without also updating check-abi's
-        # own action.yml input, silently breaking the block (checking for a
-        # label check-abi never applies).
+      - name: Require a clean ABI verdict
+        # Labels are hardcoded, not inputs: they must always match check-abi's
+        # own label defaults. Making them configurable would let a caller
+        # override them here without also updating check-abi's own action.yml
+        # input, silently breaking the block (checking for labels check-abi
+        # never applies).
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -23,4 +23,8 @@ jobs:
             echo "::error::PR is labeled 'needs-review' -- a maintainer must review and remove the label before this can merge."
             exit 1
           fi
-          echo "Label 'needs-review' not present."
+          if ! grep -qxE 'patch|minor' <<< "$LABELS"; then
+            echo "::error::PR has no 'patch' or 'minor' label -- the ABI check has not produced a verdict for this commit."
+            exit 1
+          fi
+          echo "ABI verdict present and not 'needs-review'."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Downstream triggers have been changed to match that of CI, hence we run abi-checks on push but this means, the event no longer has an associated pull request number since it is a push event. This PR changes that by fetching the PR number based on the SHA we are running the check on.
(This also allows us to label customer PRs with abi check which previously was not possible.)

- Now that labels are supposed to exist by default, this PR also fails block needs-review workflow when neither patch or minor label has been attached. If this is blocking, we can attach a patch/minor label ourselves and unblock this workflow but this is to ensure we do not allow PR to get merged because it has no label. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
