### PR TITLE
Bake llvm gpg key into ubuntu Docker images

### DIFF
--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -19,6 +19,12 @@ RUN apt-get update -qq \
 # ubuntu-toolchain-r PPA provides newer gcc versions
 RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
 
+# Bake the apt.llvm.org key so parallel CI jobs don't fetch it at runtime.
+RUN curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused --connect-timeout 15 \
+        https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && test -s /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+
 # Install dependencies for building Python from source
 RUN apt-get update \
     && apt-get -y install \

--- a/.github/docker-images/ubuntu-20-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-20-x64/Dockerfile
@@ -23,6 +23,12 @@ RUN apt-get update -qq \
 # ubuntu-toolchain-r PPA provides newer gcc versions
 RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
 
+# Bake the apt.llvm.org key so parallel CI jobs don't fetch it at runtime.
+RUN curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused --connect-timeout 15 \
+        https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && test -s /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+
 # Add the longsleep/golang-backports PPA
 RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:longsleep/golang-backports && apt-get update
 

--- a/.github/docker-images/ubuntu-22-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-22-x64/Dockerfile
@@ -24,6 +24,12 @@ RUN apt-get update -qq \
 # ubuntu-toolchain-r PPA provides newer gcc versions
 RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
 
+# Bake the apt.llvm.org key so parallel CI jobs don't fetch it at runtime.
+RUN curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused --connect-timeout 15 \
+        https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && test -s /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+
 ###############################################################################
 # Python/AWS CLI
 ###############################################################################

--- a/builder/imports/llvm.py
+++ b/builder/imports/llvm.py
@@ -98,7 +98,10 @@ esac
 
 # install everything
 if [[ $LLVM_VERSION -ne 3 ]]; then
-    curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+    # Only fetch the key here if it isn't already present in the system.
+    if [ ! -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc ]; then
+        curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+    fi
     add-apt-repository "${REPO_NAME}"
     apt-get update
 fi


### PR DESCRIPTION
Fix intermittent CI failures:
```                                                                                   
+ curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key                           
+ apt-key add -                                                                  
curl: (7) Couldn't connect to server                                             
gpg: no valid OpenPGP data found. 
```

by baking apt.llvm.org signing key into the Ubuntu 18/20/22 CI images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
